### PR TITLE
Enable service overrides for agent runtime

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ name = "open-interpreter"
 packages = [
     {include = "interpreter"},
     {include = "open_interpreter", from = "src"},
+    {include = "open_agent", from = "src"},
     {include = "scripts"},
 ]
 version = "0.4.3" # Use "-rc1", "-rc2", etc. for pre-release versions
@@ -94,6 +95,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry.scripts]
 i = "open_interpreter.interfaces.terminal.start_terminal_interface:main"
 interpreter = "open_interpreter.interfaces.terminal.start_terminal_interface:main"
+agent = "open_interpreter.interfaces.terminal.start_terminal_interface:main"
 wtf = "scripts.wtf:main"
 interpreter-classic = "open_interpreter.interfaces.terminal.start_terminal_interface:main"
 

--- a/src/open_agent/__init__.py
+++ b/src/open_agent/__init__.py
@@ -1,0 +1,58 @@
+"""Agent naming facade for the Open Interpreter runtime."""
+
+from __future__ import annotations
+
+import sys
+from importlib import import_module
+from typing import Iterable
+
+from open_interpreter import (
+    AsyncInterpreter,
+    OpenInterpreter,
+    bootstrap_registry,
+    get_global_registry,
+    ServiceKeys,
+)
+
+from .runtime import AsyncAgent, OpenAgent, agent, computer
+
+# Sub-packages exposed by ``open_interpreter`` that we mirror for the
+# ``open_agent`` namespace. Importing them eagerly ensures ``import
+# open_agent.<module>`` behaves exactly the same as the interpreter naming
+# scheme while we complete the terminology migration.
+_ALIAS_PACKAGES: tuple[str, ...] = (
+    "capabilities",
+    "core",
+    "infrastructure",
+    "interfaces",
+    "platform",
+    "services",
+)
+
+
+def _install_aliases(packages: Iterable[str]) -> None:
+    """Register alias modules so the Agent namespace mirrors Interpreter."""
+
+    for package in packages:
+        new_name = f"{__name__}.{package}"
+        if new_name in sys.modules:
+            # The alias might already exist when running in reload scenarios.
+            continue
+
+        module = import_module(f"open_interpreter.{package}")
+        sys.modules[new_name] = module
+
+
+_install_aliases(_ALIAS_PACKAGES)
+
+__all__ = [
+    "OpenAgent",
+    "AsyncAgent",
+    "agent",
+    "computer",
+    "bootstrap_registry",
+    "get_global_registry",
+    "ServiceKeys",
+    "OpenInterpreter",
+    "AsyncInterpreter",
+]

--- a/src/open_agent/runtime.py
+++ b/src/open_agent/runtime.py
@@ -1,0 +1,20 @@
+"""Runtime entrypoints for the Agent naming facade."""
+
+from __future__ import annotations
+
+from open_interpreter.runtime import (
+    AsyncInterpreter,
+    OpenInterpreter,
+    computer as _computer,
+    interpreter as _interpreter,
+)
+
+AsyncAgent = AsyncInterpreter
+OpenAgent = OpenInterpreter
+
+# ``open_interpreter`` exposes module-level singletons. Re-export them so the
+# agent terminology stays in lock-step with the existing runtime behaviour.
+agent = _interpreter
+computer = _computer
+
+__all__ = ["OpenAgent", "AsyncAgent", "agent", "computer"]

--- a/src/open_interpreter/core/runtime.py
+++ b/src/open_interpreter/core/runtime.py
@@ -75,6 +75,9 @@ class OpenInterpreter:
         multi_line=True,
         contribute_conversation=False,
         plain_text_display=False,
+        service_registry=None,
+        service_overrides=None,
+        message_renderer=None,
     ):
         # Ensure configuration required by service providers is in place before
         # we resolve the modular runtime context.
@@ -82,8 +85,11 @@ class OpenInterpreter:
 
         self.runtime = build_service_context(
             interpreter=self,
+            registry=service_registry,
             computer=computer,
             llm=llm,
+            message_renderer=message_renderer,
+            overrides=service_overrides,
         )
         self.services = self.runtime.registry
         self.state = self.runtime.conversation_state

--- a/src/open_interpreter/services/context.py
+++ b/src/open_interpreter/services/context.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, replace
 from typing import Any, Callable
 
@@ -46,37 +47,58 @@ def build_service_context(
     computer: Any | None = None,
     llm: Any | None = None,
     message_renderer: Callable[..., Any] | None = None,
+    overrides: Mapping[
+        str, Callable[..., Any] | tuple[Callable[..., Any], bool]
+    ]
+    | None = None,
 ) -> ServiceContext:
     """Construct a :class:`ServiceContext` from the registry."""
 
     resolved_registry = bootstrap_registry(registry)
+    active_registry = resolved_registry
 
-    state = resolved_registry.get(ServiceKeys.CONVERSATION_STATE)
-    history = resolved_registry.get(ServiceKeys.CONVERSATION_HISTORY)
-    renderer = message_renderer or resolved_registry.get(
+    if overrides:
+        if registry is None:
+            active_registry = resolved_registry.copy()
+
+        for name, provider in overrides.items():
+            if isinstance(provider, tuple):
+                override_provider, singleton = provider
+            else:
+                override_provider, singleton = provider, False
+
+            active_registry.override(
+                name,
+                override_provider,
+                singleton=singleton,
+            )
+
+    state = active_registry.get(ServiceKeys.CONVERSATION_STATE)
+    history = active_registry.get(ServiceKeys.CONVERSATION_HISTORY)
+    renderer = message_renderer or active_registry.get(
         ServiceKeys.MESSAGE_RENDERER, interpreter=interpreter
     )
-    manager = resolved_registry.get(
+    manager = active_registry.get(
         ServiceKeys.CONVERSATION_MANAGER,
         state=state,
         history=history,
         renderer=renderer,
     )
-    execution = resolved_registry.get(
+    execution = active_registry.get(
         ServiceKeys.EXECUTION_ORCHESTRATOR, interpreter=interpreter
     )
-    capability_store = resolved_registry.get(ServiceKeys.CAPABILITY_REGISTRY)
-    telemetry = resolved_registry.get(ServiceKeys.TELEMETRY, interpreter=interpreter)
+    capability_store = active_registry.get(ServiceKeys.CAPABILITY_REGISTRY)
+    telemetry = active_registry.get(ServiceKeys.TELEMETRY, interpreter=interpreter)
 
-    computer_service = computer or resolved_registry.get(
+    computer_service = computer or active_registry.get(
         ServiceKeys.COMPUTER, interpreter=interpreter
     )
-    llm_service = llm or resolved_registry.get(
+    llm_service = llm or active_registry.get(
         ServiceKeys.LLM, interpreter=interpreter
     )
 
     return ServiceContext(
-        registry=resolved_registry,
+        registry=active_registry,
         conversation_state=state,
         conversation_history=history,
         conversation_manager=manager,

--- a/src/open_interpreter/services/registry.py
+++ b/src/open_interpreter/services/registry.py
@@ -1,7 +1,5 @@
 """Runtime service registry used to orchestrate interpreter dependencies."""
 
-"""Runtime service registry coordinating modular components."""
-
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping
@@ -106,6 +104,16 @@ class ServiceRegistry:
 
         with self._lock:
             return tuple(sorted(self._providers.keys()))
+
+    def copy(self, *, include_singletons: bool = True) -> "ServiceRegistry":
+        """Create a shallow copy of the registry configuration."""
+
+        clone = ServiceRegistry()
+        with self._lock:
+            clone._providers = dict(self._providers)
+            if include_singletons:
+                clone._singletons = dict(self._singletons)
+        return clone
 
     @contextmanager
     def temporary_override(

--- a/tests/core/test_agent_alias.py
+++ b/tests/core/test_agent_alias.py
@@ -1,0 +1,34 @@
+"""Regression tests for the Agent terminology facade."""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+pytest.importorskip("open_interpreter")
+pytest.importorskip("open_agent")
+
+from open_agent import AsyncAgent, OpenAgent, agent, computer
+from open_interpreter import AsyncInterpreter, OpenInterpreter
+
+
+def test_runtime_aliases_share_same_objects() -> None:
+    """Agent entrypoints should be thin aliases over interpreter ones."""
+
+    from open_interpreter.runtime import computer as interpreter_computer
+    from open_interpreter.runtime import interpreter as interpreter_singleton
+
+    assert OpenAgent is OpenInterpreter
+    assert AsyncAgent is AsyncInterpreter
+    assert agent is interpreter_singleton
+    assert computer is interpreter_computer
+
+
+def test_submodule_aliases_point_to_same_module() -> None:
+    """The mirrored namespace should reuse the original module objects."""
+
+    agent_registry = importlib.import_module("open_agent.services.registry")
+    interpreter_registry = importlib.import_module("open_interpreter.services.registry")
+
+    assert agent_registry is interpreter_registry

--- a/tests/services/test_service_registry.py
+++ b/tests/services/test_service_registry.py
@@ -1,0 +1,269 @@
+"""Tests for the modular service registry infrastructure."""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+import sys
+import types
+
+
+def _install_stub_module(name: str, **attributes: Any) -> types.ModuleType:
+    module = sys.modules.get(name)
+    if module is None:
+        module = types.ModuleType(name)
+        sys.modules[name] = module
+    for attr, value in attributes.items():
+        setattr(module, attr, value)
+    return module
+
+
+_install_stub_module(
+    "litellm",
+    suppress_debug_info=False,
+    REPEATED_STREAMING_CHUNK_LIMIT=0,
+    supports_function_calling=lambda *_: False,
+    supports_vision=lambda *_: False,
+    completion=lambda *_args, **_kwargs: None,
+)
+_install_stub_module("tokentrim", trim=lambda text, *_args, **_kwargs: text)
+
+if "rich" not in sys.modules:
+    rich_module = _install_stub_module("rich", print=lambda *_args, **_kwargs: None)
+    markdown_module = types.ModuleType("rich.markdown")
+    markdown_module.Markdown = type("Markdown", (), {"__init__": lambda self, *_a, **_k: None})
+    rule_module = types.ModuleType("rich.rule")
+    rule_module.Rule = type("Rule", (), {"__init__": lambda self, *_a, **_k: None})
+    sys.modules["rich.markdown"] = markdown_module
+    sys.modules["rich.rule"] = rule_module
+
+_install_stub_module("inquirer", prompt=lambda *_a, **_k: None)
+_install_stub_module(
+    "psutil",
+    virtual_memory=lambda: type("_Mem", (), {"total": 16 * 1024**3})(),
+    disk_usage=lambda _path: type("_Disk", (), {"free": 128 * 1024**3})(),
+)
+_install_stub_module("wget", download=lambda *_a, **_k: None)
+_install_stub_module("openai")
+
+interfaces_pkg = types.ModuleType("open_interpreter.interfaces")
+interfaces_pkg.__path__ = []
+sys.modules.setdefault("open_interpreter.interfaces", interfaces_pkg)
+
+terminal_pkg = types.ModuleType("open_interpreter.interfaces.terminal")
+terminal_pkg.__path__ = []
+sys.modules.setdefault("open_interpreter.interfaces.terminal", terminal_pkg)
+
+display_module = types.ModuleType("open_interpreter.interfaces.terminal.display")
+display_module.display_markdown_message = lambda *_a, **_k: None
+sys.modules.setdefault(
+    "open_interpreter.interfaces.terminal.display", display_module
+)
+
+render_module = types.ModuleType("open_interpreter.interfaces.terminal.render")
+render_module.render_message = lambda *_a, **_k: ""
+sys.modules.setdefault(
+    "open_interpreter.interfaces.terminal.render", render_module
+)
+
+local_setup_module = types.ModuleType(
+    "open_interpreter.interfaces.terminal.local_setup"
+)
+local_setup_module.local_setup = lambda interpreter, *_a, **_k: interpreter
+sys.modules.setdefault(
+    "open_interpreter.interfaces.terminal.local_setup", local_setup_module
+)
+
+terminal_interface_module = types.ModuleType(
+    "open_interpreter.interfaces.terminal.terminal_interface"
+)
+terminal_interface_module.terminal_interface = lambda *_a, **_k: []
+sys.modules.setdefault(
+    "open_interpreter.interfaces.terminal.terminal_interface",
+    terminal_interface_module,
+)
+
+runtime_module = types.ModuleType("open_interpreter.runtime")
+runtime_module.AsyncInterpreter = type("AsyncInterpreter", (), {})
+runtime_module.OpenInterpreter = type("OpenInterpreter", (), {})
+runtime_module.computer = object()
+runtime_module.interpreter = object()
+sys.modules.setdefault("open_interpreter.runtime", runtime_module)
+
+pil_pkg = types.ModuleType("PIL")
+pil_pkg.__path__ = []
+sys.modules.setdefault("PIL", pil_pkg)
+image_module = types.ModuleType("PIL.Image")
+image_module.Image = type("Image", (), {})
+sys.modules.setdefault("PIL.Image", image_module)
+pil_pkg.Image = image_module
+
+ipython_pkg = types.ModuleType("IPython")
+ipython_pkg.__path__ = []
+sys.modules.setdefault("IPython", ipython_pkg)
+ipython_display_module = types.ModuleType("IPython.display")
+ipython_display_module.display = lambda *_a, **_k: None
+sys.modules.setdefault("IPython.display", ipython_display_module)
+ipython_pkg.display = ipython_display_module
+
+import pytest
+
+from open_interpreter.services import (
+    ServiceKeys,
+    ServiceRegistry,
+    build_service_context,
+)
+from open_interpreter.services import defaults as service_defaults
+
+
+class DummyInterpreter:
+    """Minimal interpreter stub used for service resolution tests."""
+
+
+class _DummyConversationManager(dict):
+    def __init__(self, state: Any, history: Any, renderer: Callable[..., Any]) -> None:
+        super().__init__()
+        self.state = state
+        self.history = history
+        self.renderer = renderer
+        self.messages = []
+        self.responding = False
+        self.last_messages_count = 0
+
+    def mark_checkpoint(self) -> None:  # pragma: no cover - behaviour unused in tests
+        pass
+
+    def persist_history(self, *_: Any, **__: Any) -> None:  # pragma: no cover
+        pass
+
+    def new_messages(self) -> list[Any]:  # pragma: no cover
+        return []
+
+
+class _DummyComputer:
+    def __init__(self) -> None:
+        self.skills = type("Skills", (), {"path": None})()
+        self.import_computer_api = False
+        self.import_skills = False
+        self.save_skills = True
+
+    def run(self, *_: Any, **__: Any) -> list[dict[str, Any]]:  # pragma: no cover
+        return []
+
+
+def _create_stub_registry() -> tuple[ServiceRegistry, dict[str, Any]]:
+    registry = ServiceRegistry()
+
+    sentinels: dict[str, Any] = {
+        "state": object(),
+        "history": object(),
+        "capabilities": object(),
+        "computer": _DummyComputer(),
+    }
+
+    def renderer(*_: Any, **__: Any) -> None:
+        return None
+
+    def telemetry(*_: Any, **__: Any) -> None:
+        return None
+
+    sentinels["renderer"] = renderer
+    sentinels["telemetry"] = telemetry
+
+    registry.register(ServiceKeys.CONVERSATION_STATE, lambda: sentinels["state"])
+    registry.register(
+        ServiceKeys.CONVERSATION_HISTORY,
+        lambda: sentinels["history"],
+        singleton=True,
+    )
+    registry.register(
+        ServiceKeys.MESSAGE_RENDERER,
+        lambda *, interpreter: sentinels["renderer"],
+    )
+    registry.register(
+        ServiceKeys.CONVERSATION_MANAGER,
+        lambda *, state, history, renderer: _DummyConversationManager(
+            state, history, renderer
+        ),
+    )
+    registry.register(
+        ServiceKeys.EXECUTION_ORCHESTRATOR,
+        lambda *, interpreter: ("execution", interpreter),
+    )
+    registry.register(
+        ServiceKeys.CAPABILITY_REGISTRY,
+        lambda: sentinels["capabilities"],
+        singleton=True,
+    )
+    registry.register(
+        ServiceKeys.TELEMETRY,
+        lambda *, interpreter: sentinels["telemetry"],
+    )
+    registry.register(
+        ServiceKeys.COMPUTER,
+        lambda *, interpreter: sentinels["computer"],
+        singleton=True,
+    )
+    registry.register(
+        ServiceKeys.LLM,
+        lambda *, interpreter: {"llm": interpreter},
+    )
+
+    return registry, sentinels
+
+
+def test_registry_copy_preserves_configuration_isolation() -> None:
+    registry = ServiceRegistry()
+    sentinel = object()
+
+    registry.register("single", lambda: sentinel, singleton=True)
+    registry.register("factory", lambda: object())
+
+    # Instantiate the singleton so it exists in the cache prior to copying.
+    assert registry.get("single") is sentinel
+
+    clone = registry.copy()
+
+    assert clone is not registry
+    assert clone.available_services() == registry.available_services()
+    assert clone.get("single") is sentinel
+
+    replacement = object()
+    clone.override("factory", lambda: replacement)
+
+    assert registry.get("factory") is not replacement
+    assert clone.get("factory") is replacement
+
+
+def test_build_service_context_applies_overrides_without_mutating_global(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry, sentinels = _create_stub_registry()
+
+    monkeypatch.setattr(
+        service_defaults,
+        "_global_registry",
+        registry,
+        raising=False,
+    )
+    monkeypatch.setattr(service_defaults, "_bootstrapped", False, raising=False)
+
+    override_llm = object()
+
+    context = build_service_context(
+        interpreter=DummyInterpreter(),
+        overrides={
+            ServiceKeys.LLM: (lambda *, interpreter: override_llm, True),
+        },
+    )
+
+    assert context.registry is not registry
+    assert context.llm is override_llm
+    assert context.conversation_state is sentinels["state"]
+    assert context.conversation_history is sentinels["history"]
+    assert context.message_renderer is sentinels["renderer"]
+
+    fresh_llm = service_defaults._global_registry.get(
+        ServiceKeys.LLM, interpreter=DummyInterpreter()
+    )
+    assert fresh_llm is not override_llm


### PR DESCRIPTION
## Summary
- allow the runtime facade to accept injected registries, overrides, and message renderers so agent terminology can be introduced without mutating global state
- add a cloning helper to the service registry and teach `build_service_context` to honour override maps while leaving the default wiring intact
- add regression tests that stub optional dependencies and prove registry copying and override behaviour

## Testing
- pytest tests/services/test_service_registry.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d3760f0c50832e8e66a8c8f1405b48