### PR TITLE
feat: add interactive terminal review panel and transcript logging

### DIFF
--- a/interpreter/core/utils/scan_code.py
+++ b/interpreter/core/utils/scan_code.py
@@ -1,58 +1,93 @@
 import os
 import subprocess
+from typing import Any, Dict
 
 from .temporary_file import cleanup_temporary_file, create_temporary_file
 
 try:
     from yaspin import yaspin
-    from yaspin.spinners import Spinners
-except ImportError:
-    pass
+except ImportError:  # pragma: no cover - optional dependency
+    yaspin = None  # type: ignore[assignment]
 
 
-def scan_code(code, language, interpreter):
+def scan_code(code, language, interpreter) -> Dict[str, Any]:
     """
-    Scan code with semgrep
+    Scan code with semgrep and return a structured result.
     """
+
     language_class = interpreter.computer.terminal.get_language(language)
-
     temp_file = create_temporary_file(
         code, language_class.file_extension, verbose=interpreter.verbose
     )
-
     temp_path = os.path.dirname(temp_file)
     file_name = os.path.basename(temp_file)
+
+    result: Dict[str, Any] = {
+        "status": "skipped",
+        "summary": "",
+        "return_code": None,
+        "output": "",
+    }
 
     if interpreter.verbose:
         print(f"Scanning {language} code in {file_name}")
         print("---")
 
-    # Run semgrep
+    spinner = None
     try:
-        # HACK: we need to give the subprocess shell access so that the semgrep from our pyproject.toml is available
-        # the global namespace might have semgrep from guarddog installed, but guarddog is currently
-        # pinned to an old semgrep version that has issues with reading the semgrep registry
-        # while scanning a single file like the temporary one we generate
-        # if guarddog solves [#249](https://github.com/DataDog/guarddog/issues/249) we can change this approach a bit
-        with yaspin(text="  Scanning code...").green.right.binary as loading:
-            scan = subprocess.run(
-                f"cd {temp_path} && semgrep scan --config auto --quiet --error {file_name}",
-                shell=True,
-            )
+        if yaspin:
+            spinner = yaspin(text="  Scanning code...").green.right.binary
+            spinner.start()
 
-        if scan.returncode == 0:
-            language_name = language_class.name
-            print(
-                f"  {'Code Scanner: ' if interpreter.safe_mode == 'auto' else ''}No issues were found in this {language_name} code."
-            )
+        scan = subprocess.run(
+            f"cd {temp_path} && semgrep scan --config auto --quiet --error {file_name}",
+            shell=True,
+            capture_output=True,
+            text=True,
+        )
+
+        result["return_code"] = scan.returncode
+        output_segments = [segment.strip() for segment in [scan.stdout, scan.stderr] if segment]
+        output_text = "\n".join(segment for segment in output_segments if segment)
+        result["output"] = output_text
+
+        if spinner:
+            if scan.returncode == 0:
+                spinner.ok("✔")
+            else:
+                spinner.fail("✖")
+
+        if output_text:
+            print(output_text)
             print("")
 
-        # TODO: it would be great if we could capture any vulnerabilities identified by semgrep
-        # and add them to the conversation history
+        language_name = language_class.name
+        if scan.returncode == 0:
+            result["status"] = "passed"
+            summary = (
+                f"{'Code Scanner: ' if interpreter.safe_mode == 'auto' else ''}"
+                f"No issues were found in this {language_name} code."
+            )
+            result["summary"] = summary
+            print(f"  {summary}")
+            print("")
+        else:
+            result["status"] = "issues"
+            result["summary"] = (
+                output_text or f"Potential issues detected in {language_name} code."
+            )
 
-    except Exception as e:
+    except Exception as exc:  # pragma: no cover - defensive fallback
+        if spinner:
+            spinner.fail("✖")
         print(f"Could not scan {language} code. Have you installed 'semgrep'?")
-        print(e)
+        print(exc)
         print("")  # <- Aesthetic choice
+        result["status"] = "error"
+        result["summary"] = str(exc)
+    finally:
+        if spinner:
+            spinner.stop()
+        cleanup_temporary_file(temp_file, verbose=interpreter.verbose)
 
-    cleanup_temporary_file(temp_file, verbose=interpreter.verbose)
+    return result

--- a/src/open_interpreter/interfaces/terminal/components/ui.py
+++ b/src/open_interpreter/interfaces/terminal/components/ui.py
@@ -1,0 +1,277 @@
+"""Interactive UI components for the terminal interface."""
+
+from __future__ import annotations
+
+import atexit
+import sys
+from dataclasses import dataclass
+from typing import Callable, Dict, List, Optional
+
+from rich.align import Align
+from rich.box import ROUNDED
+from rich.console import Console, Group
+from rich.live import Live
+from rich.panel import Panel
+from rich.syntax import Syntax
+from rich.table import Table
+from rich.text import Text
+
+
+def _read_key() -> str:
+    """Read a single keypress from stdin."""
+
+    # Windows support via msvcrt
+    if sys.platform.startswith("win"):
+        import msvcrt
+
+        ch = msvcrt.getwch()
+        if ch in ("\x00", "\xe0"):
+            ch += msvcrt.getwch()
+        if ch == "\x03":
+            raise KeyboardInterrupt
+        return ch
+
+    import termios
+    import tty
+
+    fd = sys.stdin.fileno()
+    old_settings = termios.tcgetattr(fd)
+    try:
+        tty.setraw(fd)
+        ch = sys.stdin.read(1)
+        if ch == "\x03":
+            raise KeyboardInterrupt
+        if ch == "\x1b":
+            # Read potential escape sequences
+            try:
+                ch += sys.stdin.read(2)
+            except Exception:
+                pass
+            return ch
+        return ch
+    finally:
+        termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
+
+
+def _normalize_keypress(key: str) -> str:
+    """Translate raw key sequences into normalized identifiers."""
+
+    if key in {"\r", "\n"}:
+        return "enter"
+    if key == "\t":
+        return "next"
+    if key == "\x1b[Z":
+        return "previous"
+    if key in {"\x1b[A", "\x1b[D", "\xe0K", "\xe0H"}:
+        return "previous"
+    if key in {"\x1b[B", "\x1b[C", "\xe0M", "\xe0P"}:
+        return "next"
+    if key.lower() in {"a", "e", "s", "q", "g", "d"}:
+        return key.lower()
+    if key == " ":
+        return "enter"
+    if key == "\x04":  # Ctrl+D
+        return "skip"
+    return key
+
+
+@dataclass
+class ReviewAction:
+    name: str
+    label: str
+    description: str
+    shortcut: str
+
+
+@dataclass
+class ReviewDecision:
+    action: str
+    scan_enabled: bool
+    default_action: Optional[str] = None
+
+
+class StatusBar:
+    """Render persistent terminal preferences in a status bar."""
+
+    def __init__(self) -> None:
+        self.console = Console()
+        self._live = Live(console=self.console, auto_refresh=False, transient=False)
+        self._started = False
+
+    def start(self) -> None:
+        if not self._started:
+            self._live.start()
+            self._started = True
+
+    def stop(self) -> None:
+        if self._started:
+            self._live.stop()
+            self._started = False
+
+    def update(self, preferences: Dict[str, object], safe_mode: str) -> None:
+        """Update the status bar with the latest preferences."""
+
+        segments: List[str] = []
+        segments.append(f"[bold]Safe[/]: {safe_mode}")
+        scan_state = "On" if preferences.get("scan", False) else "Off"
+        segments.append(f"[bold cyan]Scan[/]: {scan_state}")
+        default_action = preferences.get("default_action", "approve").title()
+        segments.append(f"[bold magenta]Default[/]: {default_action}")
+        last_decision = preferences.get("last_decision")
+        if last_decision:
+            segments.append(f"[bold green]Last[/]: {last_decision}")
+        last_scan = preferences.get("last_scan_status")
+        if last_scan:
+            segments.append(f"[bold yellow]Scan Result[/]: {last_scan}")
+
+        text = Text("  ".join(segments))
+        panel = Panel(Align.center(text), box=ROUNDED, style="white on #333333")
+
+        self.start()
+        self._live.update(panel)
+        self._live.refresh()
+
+
+status_bar = StatusBar()
+
+
+@atexit.register
+def _shutdown_status_bar() -> None:
+    status_bar.stop()
+
+
+class ReviewPanel:
+    """Interactive approval panel built with Rich."""
+
+    def __init__(
+        self,
+        *,
+        code_origin: str,
+        diff_summary: str,
+        risk_level: str,
+        runtime_estimate: str,
+        scan_enabled: bool,
+        default_action: str,
+        preferences: Dict[str, str],
+        safe_mode: str,
+        status_callback: Optional[Callable[[], None]] = None,
+        console: Optional[Console] = None,
+    ) -> None:
+        self.console = console or Console()
+        self.code_origin = code_origin
+        self.diff_summary = diff_summary
+        self.risk_level = risk_level
+        self.runtime_estimate = runtime_estimate
+        self.scan_enabled = scan_enabled
+        self.preferences = preferences
+        self.safe_mode = safe_mode
+        self.status_callback = status_callback
+
+        self.actions: List[ReviewAction] = [
+            ReviewAction("approve", "Approve & Run", "Execute the proposed code.", "a"),
+            ReviewAction(
+                "edit",
+                "Edit & Run",
+                "Open $EDITOR to review and modify before running.",
+                "e",
+            ),
+            ReviewAction("skip", "Skip", "Decline this execution.", "s"),
+        ]
+
+        self.focus_index = next(
+            (i for i, action in enumerate(self.actions) if action.name == default_action),
+            0,
+        )
+        self.message: Optional[str] = None
+        self.selected_default: Optional[str] = None
+
+    def _render_summary(self) -> Table:
+        table = Table.grid(expand=True)
+        table.add_column(style="bold cyan", width=16)
+        table.add_column(ratio=1)
+        table.add_row("Origin", self.code_origin)
+        table.add_row("Risk", self.risk_level)
+        table.add_row("Est. Runtime", self.runtime_estimate)
+        scan_state = "Enabled" if self.scan_enabled else "Disabled"
+        table.add_row("Code Scan", scan_state)
+        return table
+
+    def _render_diff(self) -> Panel:
+        diff_text = self.diff_summary or "No previous executions to diff against."
+        syntax = Syntax(diff_text, "diff", word_wrap=True)
+        return Panel(syntax, title="Diff vs last run", border_style="blue", box=ROUNDED)
+
+    def _render_actions(self) -> Table:
+        table = Table.grid(padding=(0, 1), expand=True)
+        for index, action in enumerate(self.actions):
+            is_focus = index == self.focus_index
+            base_style = "bold black on #4fc3f7" if is_focus else "white"
+            secondary_style = "black on #4fc3f7" if is_focus else "dim"
+            shortcut = action.shortcut.upper()
+            label = Text(f"[{shortcut}] {action.label}", style=base_style)
+            description = Text(action.description, style=secondary_style)
+            table.add_row(label, description)
+        return table
+
+    def _render_footer(self) -> Align:
+        hints = Text()
+        hints.append("⏎ Select", style="bold")
+        hints.append("  •  ")
+        hints.append("[G] Toggle scan", style="bold")
+        hints.append("  •  ")
+        hints.append("[D] Set default", style="bold")
+        hints.append("  •  ")
+        hints.append("[Q] Skip", style="bold")
+        if self.message:
+            hints.append(f"\n{self.message}", style="yellow")
+        return Align.center(hints)
+
+    def _render(self) -> Panel:
+        group = Group(self._render_summary(), self._render_diff(), self._render_actions(), self._render_footer())
+        return Panel(group, title="Execution Review", border_style="cyan", box=ROUNDED)
+
+    def _update_status_bar(self) -> None:
+        if self.status_callback:
+            self.status_callback()
+
+    def prompt(self) -> ReviewDecision:
+        with Live(self._render(), console=self.console, transient=True, auto_refresh=False) as live:
+            while True:
+                key = _normalize_keypress(_read_key())
+
+                if key in ("enter",):
+                    break
+
+                if key == "next":
+                    self.focus_index = (self.focus_index + 1) % len(self.actions)
+                elif key == "previous":
+                    self.focus_index = (self.focus_index - 1) % len(self.actions)
+                elif key == "a":
+                    self.focus_index = 0
+                    break
+                elif key == "e":
+                    self.focus_index = 1
+                    break
+                elif key in {"s", "q", "skip"}:
+                    self.focus_index = 2
+                    break
+                elif key == "g":
+                    self.scan_enabled = not self.scan_enabled
+                    self.preferences["scan"] = self.scan_enabled
+                    self.message = (
+                        "Code scanning enabled." if self.scan_enabled else "Code scanning disabled."
+                    )
+                    self._update_status_bar()
+                elif key == "d":
+                    default_name = self.actions[self.focus_index].name
+                    self.preferences["default_action"] = default_name
+                    self.selected_default = default_name
+                    self.message = f"Default action set to {self.actions[self.focus_index].label}."
+                    self._update_status_bar()
+
+                live.update(self._render())
+                live.refresh()
+
+        action = self.actions[self.focus_index].name
+        decision = ReviewDecision(action=action, scan_enabled=self.scan_enabled, default_action=self.selected_default)
+        return decision

--- a/src/open_interpreter/interfaces/terminal/terminal_interface.py
+++ b/src/open_interpreter/interfaces/terminal/terminal_interface.py
@@ -8,6 +8,7 @@ try:
 except ImportError:
     pass
 
+import difflib
 import os
 import platform
 import random
@@ -15,12 +16,14 @@ import re
 import subprocess
 import tempfile
 import time
+from typing import Any, Dict, Optional
 
 from ..core.utils.scan_code import scan_code
 from ..core.utils.system_debug_info import system_info
 from ..core.utils.truncate_output import truncate_output
 from .components.code_block import CodeBlock
 from .components.message_block import MessageBlock
+from .components.ui import ReviewPanel, status_bar
 from .magic_commands import handle_magic_command
 from .utils.check_for_package import check_for_package
 from .utils.cli_input import cli_input
@@ -79,6 +82,11 @@ def terminal_interface(interpreter, message):
 
     active_block = None
     voice_subprocess = None
+
+    preferences = _ensure_preferences(interpreter)
+
+    if not interpreter.plain_text_display:
+        _update_status_bar(interpreter)
 
     while True:
         if interactive:
@@ -198,67 +206,50 @@ def terminal_interface(interpreter, message):
                         language = code_to_run["format"]
                         code = code_to_run["content"]
 
-                        should_scan_code = False
+                        preferences = _ensure_preferences(interpreter)
 
-                        if not interpreter.safe_mode == "off":
-                            if interpreter.safe_mode == "auto":
-                                should_scan_code = True
-                            elif interpreter.safe_mode == "ask":
-                                response = input(
-                                    "  Would you like to scan this code? (y/n)\n\n  "
+                        panel = ReviewPanel(
+                            code_origin=_determine_code_origin(interpreter),
+                            diff_summary=_summarize_diff(
+                                preferences.get("last_executed_code"), code
+                            ),
+                            risk_level=_assess_risk(code, preferences.get("scan", False)),
+                            runtime_estimate=_estimate_runtime(code),
+                            scan_enabled=preferences.get("scan", False),
+                            default_action=preferences.get("default_action", "approve"),
+                            preferences=preferences,
+                            safe_mode=interpreter.safe_mode,
+                            status_callback=lambda: _update_status_bar(interpreter),
+                        )
+
+                        decision = panel.prompt()
+
+                        if decision.default_action:
+                            preferences["default_action"] = decision.default_action
+
+                        preferences["scan"] = decision.scan_enabled
+
+                        action = decision.action
+
+                        if action == "skip":
+                            preferences["last_decision"] = "Skipped"
+                            if interpreter.safe_mode == "off":
+                                preferences["last_scan_status"] = _log_scan_result(
+                                    interpreter,
+                                    {"status": "not_required", "summary": "Safe mode disabled."},
+                                    language,
                                 )
-                                print("")  # <- Aesthetic choice
-
-                                if response.strip().lower() == "y":
-                                    should_scan_code = True
-
-                        if should_scan_code:
-                            scan_code(code, language, interpreter)
-
-                        if interpreter.plain_text_display:
-                            response = input(
-                                "Would you like to run this code? (y/n)\n\n"
+                            else:
+                                preferences["last_scan_status"] = _log_scan_result(
+                                    interpreter, None, language
+                                )
+                            _log_transcript(
+                                interpreter,
+                                label="APPROVAL",
+                                message="Execution skipped.",
+                                emoji="no_entry_sign",
+                                style="red",
                             )
-                        else:
-                            response = input(
-                                "  Would you like to run this code? (y/n)\n\n  "
-                            )
-                        print("")  # <- Aesthetic choice
-
-                        if response.strip().lower() == "y":
-                            # Create a new, identical block where the code will actually be run
-                            # Conveniently, the chunk includes everything we need to do this:
-                            active_block = CodeBlock(interpreter)
-                            active_block.margin_top = False  # <- Aesthetic choice
-                            active_block.language = language
-                            active_block.code = code
-                        elif response.strip().lower() == "e":
-                            # Edit
-
-                            # Create a temporary file
-                            with tempfile.NamedTemporaryFile(
-                                suffix=".tmp", delete=False
-                            ) as tf:
-                                tf.write(code.encode())
-                                tf.flush()
-
-                            # Open the temporary file with the default editor
-                            subprocess.call([os.environ.get("EDITOR", "vim"), tf.name])
-
-                            # Read the modified code
-                            with open(tf.name, "r") as tf:
-                                code = tf.read()
-
-                            interpreter.messages[-1]["content"] = code  # Give it code
-
-                            # Delete the temporary file
-                            os.unlink(tf.name)
-                            active_block = CodeBlock()
-                            active_block.margin_top = False  # <- Aesthetic choice
-                            active_block.language = language
-                            active_block.code = code
-                        else:
-                            # User declined to run code.
                             interpreter.messages.append(
                                 {
                                     "role": "user",
@@ -266,7 +257,54 @@ def terminal_interface(interpreter, message):
                                     "content": "I have declined to run this code.",
                                 }
                             )
+                            _update_status_bar(interpreter)
                             break
+
+                        if action == "edit":
+                            code = _launch_editor(code, language)
+                            interpreter.messages[-1]["content"] = code
+                            preferences["last_decision"] = "Edited"
+                            _log_transcript(
+                                interpreter,
+                                label="APPROVAL",
+                                message="Code edited prior to execution.",
+                                emoji="memo",
+                                style="cyan",
+                            )
+                        else:
+                            preferences["last_decision"] = "Approved"
+                            _log_transcript(
+                                interpreter,
+                                label="APPROVAL",
+                                message="Execution approved.",
+                                emoji="white_check_mark",
+                                style="green",
+                            )
+
+                        scan_summary = None
+                        if decision.scan_enabled and interpreter.safe_mode != "off":
+                            scan_summary = scan_code(code, language, interpreter)
+                            preferences["last_scan_status"] = _log_scan_result(
+                                interpreter, scan_summary, language
+                            )
+                        elif interpreter.safe_mode == "off":
+                            preferences["last_scan_status"] = _log_scan_result(
+                                interpreter,
+                                {"status": "not_required", "summary": "Safe mode disabled."},
+                                language,
+                            )
+                        else:
+                            preferences["last_scan_status"] = _log_scan_result(
+                                interpreter, None, language
+                            )
+
+                        preferences["last_executed_code"] = code
+                        _update_status_bar(interpreter)
+
+                        active_block = CodeBlock(interpreter)
+                        active_block.margin_top = False  # <- Aesthetic choice
+                        active_block.language = language
+                        active_block.code = code
 
                 # Plain text mode
                 if interpreter.plain_text_display:
@@ -539,3 +577,237 @@ def terminal_interface(interpreter, message):
             if interpreter.debug:
                 system_info(interpreter)
             raise
+
+
+def _ensure_preferences(interpreter) -> Dict[str, Any]:
+    existing = getattr(interpreter, "terminal_preferences", None)
+    if not isinstance(existing, dict):
+        existing = {}
+
+    defaults: Dict[str, Any] = {
+        "scan": interpreter.safe_mode != "off",
+        "default_action": "approve",
+        "last_decision": None,
+        "last_scan_status": None,
+        "last_executed_code": "",
+    }
+
+    for key, value in defaults.items():
+        existing.setdefault(key, value)
+
+    interpreter.terminal_preferences = existing
+    return existing
+
+
+def _update_status_bar(interpreter) -> None:
+    if getattr(interpreter, "plain_text_display", False):
+        return
+    preferences = _ensure_preferences(interpreter)
+    status_bar.update(preferences, interpreter.safe_mode)
+
+
+def _determine_code_origin(interpreter) -> str:
+    model_name = getattr(interpreter.llm, "model", None)
+    origin = model_name or "Assistant"
+    last_assistant_code = next(
+        (
+            message
+            for message in reversed(interpreter.messages)
+            if message.get("role") == "assistant" and message.get("type") == "code"
+        ),
+        None,
+    )
+    if last_assistant_code and last_assistant_code.get("metadata"):
+        origin = last_assistant_code["metadata"].get("origin", origin)
+    return origin
+
+
+def _summarize_diff(previous_code: Optional[str], current_code: str) -> str:
+    if not previous_code:
+        return "No previous execution."
+
+    diff_lines = list(
+        difflib.unified_diff(
+            previous_code.splitlines(),
+            current_code.splitlines(),
+            fromfile="previous",
+            tofile="current",
+            lineterm="",
+        )
+    )
+    diff_lines = [line for line in diff_lines if line.strip()]
+
+    if not diff_lines:
+        return "No changes since last run."
+
+    max_lines = 12
+    if len(diff_lines) > max_lines:
+        diff_lines = diff_lines[:max_lines] + ["..."]
+    return "\n".join(diff_lines)
+
+
+def _assess_risk(code: str, scan_enabled: bool) -> str:
+    lowered = code.lower()
+    high_risk_patterns = ["rm -rf", "del /q", "shutdown", "format ", "drop table", "sudo"]
+    medium_risk_patterns = [
+        "subprocess",
+        "os.remove",
+        "shutil.rmtree",
+        "eval(",
+        "exec(",
+        "while true",
+    ]
+
+    risk_level = "Low"
+    style = "green"
+
+    if any(pattern in lowered for pattern in high_risk_patterns):
+        risk_level = "High"
+        style = "red"
+    elif any(pattern in lowered for pattern in medium_risk_patterns) or len(code.splitlines()) > 80:
+        risk_level = "Moderate"
+        style = "yellow"
+
+    suffix = " (scan enabled)" if scan_enabled else " (scan off)"
+    return f"[{style}]{risk_level}[/] risk{suffix}"
+
+
+def _estimate_runtime(code: str) -> str:
+    line_count = len([line for line in code.splitlines() if line.strip()])
+    long_running_signals = ["time.sleep", "asyncio.sleep", "subprocess.run", "requests.get"]
+
+    if any(signal in code for signal in long_running_signals):
+        return "Likely longer (>10s)"
+    if line_count <= 10:
+        return "Short (<2s)"
+    if line_count <= 40:
+        return "Moderate (≈5s)"
+    return "Extended (>10s)"
+
+
+def _launch_editor(code: str, language: str) -> str:
+    suffix = ".tmp"
+    if language:
+        sanitized = re.sub(r"[^a-zA-Z0-9]+", "", language.split("/")[-1])
+        if sanitized:
+            suffix = f".{sanitized}"
+
+    with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as temp_file:
+        temp_file.write(code.encode())
+        temp_file.flush()
+        temp_path = temp_file.name
+
+    try:
+        subprocess.call([os.environ.get("EDITOR", "vim"), temp_path])
+        with open(temp_path, "r") as updated:
+            return updated.read()
+    finally:
+        try:
+            os.unlink(temp_path)
+        except FileNotFoundError:
+            pass
+
+
+def _log_transcript(
+    interpreter,
+    *,
+    label: str,
+    message: str,
+    emoji: str = "memo",
+    style: str = "green",
+) -> None:
+    content = f":{emoji}: [bold {style}][{label}][/bold {style}] {message}"
+    entry = {
+        "role": "system",
+        "type": "message",
+        "content": content,
+        "recipient": "user",
+    }
+    interpreter.messages.append(entry)
+    interpreter.display_message(content)
+
+
+def _log_scan_result(
+    interpreter,
+    scan_result: Optional[Dict[str, Any]],
+    language: str,
+) -> str:
+    language_label = language or "code"
+
+    if not scan_result:
+        _log_transcript(
+            interpreter,
+            label="SCAN",
+            message=f"{language_label} scan skipped by user.",
+            emoji="shield",
+            style="yellow",
+        )
+        return "Skipped"
+
+    status = str(scan_result.get("status", "unknown")).lower()
+    summary = scan_result.get("summary", "") or ""
+    output = scan_result.get("output", "") or ""
+
+    if status == "passed":
+        message = summary or f"No issues were found in this {language_label} code."
+        _log_transcript(
+            interpreter,
+            label="SCAN",
+            message=message,
+            emoji="shield",
+            style="green",
+        )
+        return "Passed"
+
+    if status in {"issues", "failed"}:
+        snippet = _truncate_text(summary or output)
+        detail = f"\n\n```\n{snippet}\n```" if snippet else ""
+        _log_transcript(
+            interpreter,
+            label="SCAN",
+            message=f"Potential issues detected in {language_label}.{detail}",
+            emoji="shield",
+            style="red",
+        )
+        return "Issues detected"
+
+    if status in {"error", "exception"}:
+        message = summary or "Scan encountered an error."
+        _log_transcript(
+            interpreter,
+            label="SCAN",
+            message=f"Scan error for {language_label}: {message}",
+            emoji="shield",
+            style="yellow",
+        )
+        return "Error"
+
+    if status in {"skipped", "not required", "not_required"}:
+        message = summary or f"{language_label} scan skipped."
+        _log_transcript(
+            interpreter,
+            label="SCAN",
+            message=message,
+            emoji="shield",
+            style="yellow",
+        )
+        if status in {"not required", "not_required"}:
+            return "Not required"
+        return "Skipped"
+
+    message = summary or f"Scan status: {status}."
+    _log_transcript(
+        interpreter,
+        label="SCAN",
+        message=message,
+        emoji="shield",
+        style="yellow",
+    )
+    return status.title()
+
+
+def _truncate_text(text: str, limit: int = 400) -> str:
+    text = text.strip()
+    if len(text) <= limit:
+        return text
+    return text[: limit - 3] + "..."


### PR DESCRIPTION
## Summary
- add a Rich-powered review panel with keyboard shortcuts and a persistent status bar for terminal approvals
- replace manual execution prompts with the new panel, logging approvals and scan decisions into the transcript
- return structured results from the code scanner to surface pass/fail summaries in the UI

## Testing
- python -m compileall interpreter/core/utils/scan_code.py src/open_interpreter/interfaces/terminal

------
https://chatgpt.com/codex/tasks/task_e_68d6388cfa94832e8ec5fb7d50660140