### PR TITLE
Improve terminal streaming performance and asset handling

### DIFF
--- a/src/open_interpreter/interfaces/terminal/components/code_block.py
+++ b/src/open_interpreter/interfaces/terminal/components/code_block.py
@@ -20,6 +20,11 @@ class CodeBlock(BaseBlock):
             interpreter.highlight_active_line if interpreter else None
         )
 
+        # A shared cache used for pre-rendered syntax objects. This is optional
+        # and is primarily populated by utilities that replay past
+        # conversations.
+        self.syntax_cache = None
+
         # Define these for IDE auto-completion
         self.language = ""
         self.output = ""
@@ -56,25 +61,39 @@ class CodeBlock(BaseBlock):
         # Add each line of code to the table
         code_lines = code.strip().split("\n")
         for i, line in enumerate(code_lines, start=1):
-            if i == self.active_line and (
-                self.highlight_active_line
-                if self.highlight_active_line is not None
-                else True
-            ):
-                # This is the active line, print it with a white background
-                syntax = Syntax(
-                    line, self.language, theme="bw", line_numbers=False, word_wrap=True
+            is_active_line = (
+                i == self.active_line
+                and (
+                    self.highlight_active_line
+                    if self.highlight_active_line is not None
+                    else True
                 )
-                code_table.add_row(syntax, style="black on white")
+            )
+
+            theme = "bw" if is_active_line else "monokai"
+            cache_key = None
+
+            if self.syntax_cache is not None:
+                cache_key = (self.language, line, theme)
+                syntax = self.syntax_cache.get(cache_key)
             else:
-                # This is not the active line, print it normally
+                syntax = None
+
+            if syntax is None:
                 syntax = Syntax(
                     line,
                     self.language,
-                    theme="monokai",
+                    theme=theme,
                     line_numbers=False,
                     word_wrap=True,
                 )
+
+                if cache_key and self.syntax_cache is not None:
+                    self.syntax_cache[cache_key] = syntax
+
+            if is_active_line:
+                code_table.add_row(syntax, style="black on white")
+            else:
                 code_table.add_row(syntax)
 
         # Create a panel for the code

--- a/src/open_interpreter/interfaces/terminal/render_past_conversation.py
+++ b/src/open_interpreter/interfaces/terminal/render_past_conversation.py
@@ -3,67 +3,93 @@ This is all messed up.... Uses the old streaming structure.
 """
 
 
+import itertools
+
 from .components.code_block import CodeBlock
 from .components.message_block import MessageBlock
 from .utils.display_markdown_message import display_markdown_message
 
 
-def render_past_conversation(messages):
+def render_past_conversation(messages, page_size=200):
     # This is a clone of the terminal interface.
     # So we should probably find a way to deduplicate...
 
     active_block = None
     render_cursor = False
     ran_code_block = False
+    syntax_cache = {}
+    rendered_count = 0
 
-    for chunk in messages:
-        # Only addition to the terminal interface:
-        if chunk["role"] == "user":
-            if active_block:
-                active_block.end()
-                active_block = None
-            print(">", chunk["content"])
-            continue
+    messages_iter = iter(messages)
 
-        # Message
-        if chunk["type"] == "message":
-            if active_block is None:
-                active_block = MessageBlock()
-            if active_block.type != "message":
-                active_block.end()
-                active_block = MessageBlock()
-            active_block.message += chunk["content"]
+    def prompt_for_more(rendered_count):
+        try:
+            response = input(
+                f"\n-- Displayed {rendered_count} transcript chunks. Press <enter> to load more, or type 'q' to stop: "
+            )
+        except (EOFError, KeyboardInterrupt):
+            return False
+        return response.strip().lower() not in {"q", "quit", "exit"}
 
-        # Code
-        if chunk["type"] == "code":
-            if active_block is None:
-                active_block = CodeBlock()
-            if active_block.type != "code" or ran_code_block:
-                # If the last block wasn't a code block,
-                # or it was, but we already ran it:
-                active_block.end()
-                active_block = CodeBlock()
-            ran_code_block = False
-            render_cursor = True
+    while True:
+        page = list(itertools.islice(messages_iter, page_size))
+        if not page:
+            break
 
-            if "format" in chunk:
-                active_block.language = chunk["format"]
-            if "content" in chunk:
-                active_block.code += chunk["content"]
-            if "active_line" in chunk:
-                active_block.active_line = chunk["active_line"]
+        for chunk in page:
+            # Only addition to the terminal interface:
+            if chunk["role"] == "user":
+                if active_block:
+                    active_block.end()
+                    active_block = None
+                print(">", chunk["content"])
+                continue
 
-        # Console
-        if chunk["type"] == "console":
-            ran_code_block = True
-            render_cursor = False
-            active_block.output += "\n" + chunk["content"]
-            active_block.output = active_block.output.strip()  # <- Aesthetic choice
+            # Message
+            if chunk["type"] == "message":
+                if active_block is None or active_block.type != "message":
+                    if active_block:
+                        active_block.end()
+                    active_block = MessageBlock()
+                render_cursor = True
+                active_block.message += chunk["content"]
+                active_block.refresh(cursor=render_cursor)
+                continue
 
-        if active_block:
-            active_block.refresh(cursor=render_cursor)
+            # Code
+            if chunk["type"] == "code":
+                if active_block is None or active_block.type != "code" or ran_code_block:
+                    if active_block:
+                        active_block.end()
+                    active_block = CodeBlock()
+                    active_block.syntax_cache = syntax_cache
+                ran_code_block = False
+                render_cursor = True
 
-    # (Sometimes -- like if they CTRL-C quickly -- active_block is still None here)
+                if "format" in chunk:
+                    active_block.language = chunk["format"]
+                if "content" in chunk:
+                    active_block.code += chunk["content"]
+                if "active_line" in chunk:
+                    active_block.active_line = chunk["active_line"]
+                active_block.refresh(cursor=render_cursor)
+                continue
+
+            # Console
+            if chunk["type"] == "console" and active_block:
+                ran_code_block = True
+                render_cursor = False
+                active_block.output += "\n" + chunk["content"]
+                active_block.output = active_block.output.strip()  # <- Aesthetic choice
+                active_block.refresh(cursor=render_cursor)
+
+        rendered_count += len(page)
+
+        if len(page) < page_size:
+            break
+
+        if not prompt_for_more(rendered_count):
+            break
+
     if active_block:
         active_block.end()
-        active_block = None

--- a/src/open_interpreter/interfaces/terminal/terminal_interface.py
+++ b/src/open_interpreter/interfaces/terminal/terminal_interface.py
@@ -159,6 +159,76 @@ def terminal_interface(interpreter, message):
                     }
 
         try:
+            pending_updates = {
+                "code": [],
+                "output": [],
+                "active_line": None,
+            }
+            last_refresh_time = time.monotonic()
+            MIN_REFRESH_INTERVAL = 0.05
+            render_cursor = False
+
+            def reset_pending():
+                pending_updates["code"].clear()
+                pending_updates["output"].clear()
+                pending_updates["active_line"] = None
+
+            def flush_pending(force=False):
+                nonlocal last_refresh_time
+
+                if not active_block:
+                    reset_pending()
+                    return
+
+                has_updates = bool(pending_updates["code"]) or bool(
+                    pending_updates["output"]
+                ) or pending_updates["active_line"] is not None
+
+                if not has_updates:
+                    return
+
+                now = time.monotonic()
+                if not force and now - last_refresh_time < MIN_REFRESH_INTERVAL:
+                    return
+
+                updated = False
+
+                if pending_updates["code"] and hasattr(active_block, "code"):
+                    active_block.code += "".join(pending_updates["code"])
+                    pending_updates["code"].clear()
+                    updated = True
+
+                if pending_updates["output"] and hasattr(active_block, "output"):
+                    appended_output = "\n".join(
+                        [chunk for chunk in pending_updates["output"] if chunk]
+                    )
+                    pending_updates["output"].clear()
+
+                    if appended_output:
+                        if active_block.output:
+                            active_block.output += "\n" + appended_output
+                        else:
+                            active_block.output = appended_output
+
+                        active_block.output = active_block.output.strip()
+                        active_block.output = truncate_output(
+                            active_block.output,
+                            interpreter.max_output,
+                            add_scrollbars=False,
+                        )
+                        updated = True
+
+                if pending_updates["active_line"] is not None and hasattr(
+                    active_block, "active_line"
+                ):
+                    active_block.active_line = pending_updates["active_line"]
+                    pending_updates["active_line"] = None
+                    updated = True
+
+                if updated:
+                    active_block.refresh(cursor=render_cursor)
+                    last_refresh_time = now
+
             for chunk in interpreter.chat(message, display=False, stream=True):
                 yield chunk
 
@@ -176,6 +246,7 @@ def terminal_interface(interpreter, message):
                         chunk.get("format") == "output"
                         and "failsafeexception" in chunk["content"].lower()
                     ):
+                        flush_pending(force=True)
                         print("Fail-safe triggered (mouse in one of the four corners).")
                         break
 
@@ -193,6 +264,7 @@ def terminal_interface(interpreter, message):
                             active_block.refresh(cursor=False)
                             active_block.end()
                             active_block = None
+                            reset_pending()
 
                         code_to_run = chunk["content"]
                         language = code_to_run["format"]
@@ -282,6 +354,7 @@ def terminal_interface(interpreter, message):
                     continue
 
                 if "end" in chunk and active_block:
+                    flush_pending(force=True)
                     active_block.refresh(cursor=False)
 
                     if chunk["type"] in [
@@ -290,15 +363,19 @@ def terminal_interface(interpreter, message):
                     ]:  # We don't stop on code's end — code + console output are actually one block.
                         active_block.end()
                         active_block = None
+                        reset_pending()
 
                 # Assistant message blocks
                 if chunk["type"] == "message":
+                    flush_pending(force=True)
+
                     if "start" in chunk:
                         active_block = MessageBlock()
                         render_cursor = True
 
                     if "content" in chunk:
                         active_block.message += chunk["content"]
+                        active_block.refresh(cursor=render_cursor)
 
                     if "end" in chunk and interpreter.os:
                         last_message = interpreter.messages[-1]["content"]
@@ -345,12 +422,16 @@ def terminal_interface(interpreter, message):
                 # Assistant code blocks
                 elif chunk["role"] == "assistant" and chunk["type"] == "code":
                     if "start" in chunk:
+                        flush_pending(force=True)
+
                         active_block = CodeBlock()
                         active_block.language = chunk["format"]
                         render_cursor = True
+                        reset_pending()
 
                     if "content" in chunk:
-                        active_block.code += chunk["content"]
+                        pending_updates["code"].append(chunk["content"])
+                        flush_pending(force="\n" in chunk["content"])
 
                 # Computer can display visual types to user,
                 # Which sometimes creates more computer output (e.g. HTML errors, eventually)
@@ -422,21 +503,15 @@ def terminal_interface(interpreter, message):
 
                 # Console
                 if chunk["type"] == "console":
+                    if not active_block:
+                        continue
                     render_cursor = False
                     if "format" in chunk and chunk["format"] == "output":
-                        active_block.output += "\n" + chunk["content"]
-                        active_block.output = (
-                            active_block.output.strip()
-                        )  # ^ Aesthetic choice
-
-                        # Truncate output
-                        active_block.output = truncate_output(
-                            active_block.output,
-                            interpreter.max_output,
-                            add_scrollbars=False,
-                        )  # ^ Notice that this doesn't add the "scrollbars" line, which I think is fine
+                        pending_updates["output"].append(chunk["content"])
+                        flush_pending(force="\n" in chunk["content"])
                     if "format" in chunk and chunk["format"] == "active_line":
-                        active_block.active_line = chunk["content"]
+                        pending_updates["active_line"] = chunk["content"]
+                        flush_pending(force=True)
 
                         # Display action notifications if we're in OS mode
                         if interpreter.os and active_block.active_line != None:
@@ -509,12 +584,14 @@ def terminal_interface(interpreter, message):
                             if active_block:
                                 active_block.end()
                             active_block = CodeBlock()
+                            reset_pending()
 
                 if active_block:
-                    active_block.refresh(cursor=render_cursor)
+                    flush_pending()
 
             # (Sometimes -- like if they CTRL-C quickly -- active_block is still None here)
             if "active_block" in locals():
+                flush_pending(force=True)
                 if active_block:
                     active_block.end()
                     active_block = None

--- a/src/open_interpreter/interfaces/terminal/utils/display_output.py
+++ b/src/open_interpreter/interfaces/terminal/utils/display_output.py
@@ -1,10 +1,66 @@
+import atexit
 import base64
 import os
 import platform
 import subprocess
 import tempfile
 
+from typing import List
+
 from .in_jupyter_notebook import in_jupyter_notebook
+
+
+_TEMP_ASSETS: List[str] = []
+
+
+def _register_temp_asset(path: str) -> None:
+    _TEMP_ASSETS.append(path)
+
+
+@atexit.register
+def _cleanup_temp_assets() -> None:
+    for path in list(_TEMP_ASSETS):
+        try:
+            if os.path.exists(path):
+                os.remove(path)
+        except OSError:
+            pass
+
+
+def _compress_text_asset(content: str) -> str:
+    # Collapse trailing whitespace and duplicate blank lines to reduce file size
+    lines = [line.rstrip() for line in content.splitlines()]
+    compressed_lines = []
+    previous_blank = False
+
+    for line in lines:
+        if line:
+            compressed_lines.append(line)
+            previous_blank = False
+        else:
+            if not previous_blank:
+                compressed_lines.append(line)
+            previous_blank = True
+
+    return "\n".join(compressed_lines).strip()
+
+
+def _optimize_image_file(path: str) -> None:
+    try:
+        from PIL import Image
+    except ImportError:
+        return
+
+    try:
+        with Image.open(path) as img:
+            save_kwargs = {"optimize": True}
+            if img.format == "JPEG":
+                # Maintain a balance between quality and size
+                save_kwargs.setdefault("quality", 85)
+            img.save(path, **save_kwargs)
+    except Exception:
+        # Best effort compression only
+        pass
 
 
 def display_output(output):
@@ -49,27 +105,35 @@ def display_output_cli(output):
                 image_data = base64.b64decode(output["content"])
                 tmp_file.write(image_data)
 
+            _optimize_image_file(tmp_file.name)
+            _register_temp_asset(tmp_file.name)
+
                 # # Display in Terminal (DISABLED, i couldn't get it to work)
                 # from term_image.image import from_file
                 # image = from_file(tmp_file.name)
                 # image.draw()
 
-                open_file(tmp_file.name)
+            open_file(tmp_file.name)
         elif output["format"] == "path":
             open_file(output["content"])
     elif "format" in output and output["format"] == "html":
         with tempfile.NamedTemporaryFile(
-            delete=False, suffix=".html", mode="w"
+            delete=False, suffix=".html", mode="w", encoding="utf-8"
         ) as tmp_file:
-            html = output["content"]
+            html = _compress_text_asset(output["content"])
             tmp_file.write(html)
-            open_file(tmp_file.name)
+
+        _register_temp_asset(tmp_file.name)
+        open_file(tmp_file.name)
     elif "format" in output and output["format"] == "javascript":
         with tempfile.NamedTemporaryFile(
-            delete=False, suffix=".js", mode="w"
+            delete=False, suffix=".js", mode="w", encoding="utf-8"
         ) as tmp_file:
-            tmp_file.write(output["content"])
-            open_file(tmp_file.name)
+            script = _compress_text_asset(output["content"])
+            tmp_file.write(script)
+
+        _register_temp_asset(tmp_file.name)
+        open_file(tmp_file.name)
 
 
 def open_file(file_path):


### PR DESCRIPTION
## Summary
- batch terminal code updates with chunk diffing to reduce redundant redraws during streaming
- virtualize past transcript playback with page-based loading and shared syntax cache reuse
- cache syntax highlighting entries and automatically compress and clean up temporary display assets

## Testing
- python -m compileall src/open_interpreter/interfaces/terminal

------
https://chatgpt.com/codex/tasks/task_e_68d63899ca7c832e80a5426dd842b3b5