### PR TITLE
Enhance terminal CLI UX and profile management

### DIFF
--- a/src/open_interpreter/core/runtime.py
+++ b/src/open_interpreter/core/runtime.py
@@ -121,6 +121,11 @@ class OpenInterpreter:
         self.contribute_conversation = contribute_conversation
         self.plain_text_display = plain_text_display
         self.highlight_active_line = True  # additional setting to toggle active line highlighting. Defaults to True
+        self.profile_metadata = {}
+        self.active_profile = {}
+        self._cli_overrides = {}
+        self._cli_attribute_map = {}
+        self._command_palette_enabled = True
 
         # Loop messages
         self.loop = loop

--- a/src/open_interpreter/interfaces/terminal/command_palette.py
+++ b/src/open_interpreter/interfaces/terminal/command_palette.py
@@ -1,0 +1,96 @@
+"""Interactive command palette utilities for the terminal interface."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from rich.console import Console
+from rich.prompt import Prompt
+from rich.table import Table
+from rich.text import Text
+
+from .profiles.profiles import list_available_profiles, profile
+from .utils.cli_overrides import apply_cli_overrides
+from .utils.session_header import display_session_header
+
+console = Console()
+
+
+def open_command_palette(interpreter: Any) -> None:
+    """Launch the command palette for runtime actions."""
+
+    if not getattr(interpreter, "_command_palette_enabled", True):
+        console.print("\n[yellow]Command palette is not available in this mode.[/yellow]\n")
+        return
+
+    options = [
+        ("Switch profile", _handle_switch_profile),
+        ("Show active profile", _handle_show_profile),
+        ("Cancel", None),
+    ]
+
+    console.print("\n[bold cyan]Command Palette[/bold cyan]")
+    table = Table(show_header=False, box=None, padding=(0, 1))
+
+    for index, (label, _) in enumerate(options, start=1):
+        table.add_row(f"[cyan]{index}[/cyan]", label)
+
+    console.print(table)
+
+    valid_choices = [str(index) for index in range(1, len(options) + 1)] + ["q"]
+    selection = Prompt.ask("Select an action", choices=valid_choices, default="q")
+
+    if selection == "q":
+        console.print("")
+        return
+
+    handler = options[int(selection) - 1][1]
+    if handler:
+        handler(interpreter)
+
+    console.print("")
+
+
+def _handle_switch_profile(interpreter: Any) -> None:
+    profiles = list_available_profiles()
+    if not profiles:
+        console.print("[yellow]No profiles were found to switch to.[/yellow]")
+        return
+
+    table = Table(show_header=True, header_style="bold magenta")
+    table.add_column("#", style="cyan", width=4)
+    table.add_column("Profile")
+    table.add_column("Source", style="dim")
+    table.add_column("Format", style="dim")
+
+    for index, item in enumerate(profiles, start=1):
+        source = item.get("source", "unknown")
+        table.add_row(
+            str(index),
+            item.get("name", ""),
+            source,
+            item.get("format", ""),
+        )
+
+    console.print(table)
+
+    valid_choices = [str(index) for index in range(1, len(profiles) + 1)] + ["q"]
+    selection = Prompt.ask("Switch to", choices=valid_choices, default="q")
+
+    if selection == "q":
+        return
+
+    chosen_profile = profiles[int(selection) - 1]
+    profile(interpreter, chosen_profile["identifier"])
+    apply_cli_overrides(interpreter)
+    console.print(
+        Text(
+            f"Switched to profile '{chosen_profile['name']}'",
+            style="green",
+        )
+    )
+    display_session_header(interpreter)
+
+
+def _handle_show_profile(interpreter: Any) -> None:
+    display_session_header(interpreter)

--- a/src/open_interpreter/interfaces/terminal/profiles/profiles.py
+++ b/src/open_interpreter/interfaces/terminal/profiles/profiles.py
@@ -1,12 +1,14 @@
 import ast
 import glob
 import json
+import logging
 import os
 import platform
 import shutil
 import string
 import subprocess
 import time
+from typing import Callable
 
 import platformdirs
 import requests
@@ -28,7 +30,117 @@ default_profiles_names = [os.path.basename(path) for path in default_profiles_pa
 OI_VERSION = "0.2.5"
 
 
+logger = logging.getLogger(__name__)
+
+
+def _profile_format(name: str) -> str:
+    extension = os.path.splitext(name)[1].lower()
+    if extension in {".yaml", ".yml"}:
+        return "yaml"
+    if extension == ".json":
+        return "json"
+    if extension == ".py":
+        return "python"
+    return "unknown"
+
+
+def _determine_profile_source(filename_or_url: str, profile_path: str) -> str:
+    if filename_or_url in default_profiles_names:
+        return "default"
+    if filename_or_url.startswith(("http://", "https://")):
+        return "remote"
+    if os.path.exists(profile_path):
+        return "user"
+    return "custom"
+
+
+def _resolve_profile_path(filename_or_url: str, profile_path: str) -> str | None:
+    if filename_or_url in default_profiles_names:
+        return os.path.join(oi_default_profiles_path, filename_or_url)
+    if os.path.exists(profile_path):
+        return profile_path
+    if filename_or_url.startswith(("http://", "https://")):
+        return filename_or_url
+    return profile_path if profile_path else None
+
+
+def _build_profile_metadata(
+    name: str,
+    origin: str,
+    path: str | None,
+    source: str,
+    profile_data,
+) -> dict:
+    metadata = {
+        "name": name,
+        "origin": origin,
+        "path": path,
+        "source": source,
+        "format": _profile_format(name),
+        "version": None,
+    }
+
+    if isinstance(profile_data, dict):
+        metadata["version"] = profile_data.get("version")
+
+    return metadata
+
+
+def _safe_read_profile_version(path: str) -> str | None:
+    try:
+        if path.endswith((".yaml", ".yml")):
+            with open(path, "r", encoding="utf-8") as file:
+                data = yaml.safe_load(file)
+            if isinstance(data, dict):
+                return data.get("version")
+        elif path.endswith(".json"):
+            with open(path, "r", encoding="utf-8") as file:
+                data = json.load(file)
+            if isinstance(data, dict):
+                return data.get("version")
+    except Exception:
+        logger.debug("Failed to read profile version from %s", path, exc_info=True)
+    return None
+
+
+def list_available_profiles() -> list[dict]:
+    profiles: list[dict] = []
+
+    for path in sorted(default_profiles_paths):
+        name = os.path.basename(path)
+        profiles.append(
+            {
+                "name": name,
+                "identifier": name,
+                "source": "default",
+                "path": path,
+                "format": _profile_format(name),
+                "version": OI_VERSION,
+            }
+        )
+
+    if os.path.exists(profile_dir):
+        for name in sorted(os.listdir(profile_dir)):
+            file_path = os.path.join(profile_dir, name)
+            if not os.path.isfile(file_path):
+                continue
+
+            profiles.append(
+                {
+                    "name": name,
+                    "identifier": name,
+                    "source": "user",
+                    "path": file_path,
+                    "format": _profile_format(name),
+                    "version": _safe_read_profile_version(file_path),
+                }
+            )
+
+    return sorted(profiles, key=lambda item: (item["source"] != "default", item["name"].lower()))
+
+
 def profile(interpreter, filename_or_url):
+    requested_profile = filename_or_url
     # See if they're doing shorthand for a default profile
     filename_without_extension = os.path.splitext(filename_or_url)[0]
     for profile in default_profiles_names:
@@ -61,7 +173,23 @@ def profile(interpreter, filename_or_url):
             else:
                 raise
 
-    return apply_profile(interpreter, profile, profile_path)
+    interpreter = apply_profile(interpreter, profile, profile_path)
+
+    resolved_name = os.path.basename(filename_or_url)
+    metadata_path = _resolve_profile_path(filename_or_url, profile_path)
+    source = _determine_profile_source(filename_or_url, profile_path)
+    metadata = _build_profile_metadata(
+        resolved_name,
+        requested_profile,
+        metadata_path,
+        source,
+        profile,
+    )
+
+    interpreter.profile_metadata = metadata
+    interpreter.active_profile = metadata
+
+    return interpreter
 
 
 def get_profile(filename_or_url, profile_path):
@@ -588,66 +716,85 @@ def open_storage_dir(directory):
     return
 
 
-def reset_profile(specific_default_profile=None):
-    if (
-        specific_default_profile
-        and specific_default_profile not in default_profiles_names
-    ):
+def reset_profile(
+    specific_default_profile=None,
+    *,
+    non_interactive: bool = False,
+    confirm: bool = False,
+    log: Callable[[str], None] | None = None,
+) -> list[str]:
+    logger_fn = log or logger.info
+
+    if specific_default_profile in {None, "NOT_PROVIDED", "default"}:
+        targets = ["default.yaml"]
+    elif specific_default_profile in default_profiles_names:
+        targets = [specific_default_profile]
+    else:
         raise ValueError(
             f"The specific default profile '{specific_default_profile}' is not a default profile."
         )
 
-    # Check version, before making the profile directory
+    summary: list[str] = []
     current_version = determine_user_version()
+    os.makedirs(profile_dir, exist_ok=True)
 
-    for default_yaml_file in default_profiles_paths:
-        filename = os.path.basename(default_yaml_file)
-
-        if specific_default_profile and filename != specific_default_profile:
-            continue
-
-        # Only reset default.yaml, all else are loaded from python package
-        if specific_default_profile != "default.yaml":
-            continue
-
+    for filename in targets:
+        default_path = os.path.join(oi_default_profiles_path, filename)
         target_file = os.path.join(profile_dir, filename)
 
-        # Variable to see if we should display the 'reset' print statement or not
-        create_oi_directory = False
-
-        # Make the profile directory if it does not exist
-        if not os.path.exists(profile_dir):
-            if not os.path.exists(oi_dir):
-                create_oi_directory = True
-
-            os.makedirs(profile_dir)
+        if not os.path.exists(default_path):
+            message = f"Default profile '{filename}' could not be found."
+            logger_fn(message)
+            if not non_interactive:
+                print(message)
+            summary.append(message)
+            continue
 
         if not os.path.exists(target_file):
-            shutil.copy(default_yaml_file, target_file)
+            shutil.copy(default_path, target_file)
             if current_version is None:
-                # If there is no version, add it to the default yaml
                 with open(target_file, "a") as file:
                     file.write(
                         f"\nversion: {OI_VERSION}  # Profile version (do not modify)"
                     )
-            if not create_oi_directory:
-                print(f"{filename} has been reset.")
-        else:
-            with open(target_file, "r") as file:
-                current_profile = file.read()
-            if current_profile not in historical_profiles:
-                user_input = input(f"Would you like to reset/update {filename}? (y/n) ")
-                if user_input.lower() == "y":
-                    send2trash.send2trash(
-                        target_file
-                    )  # This way, people can recover it from the trash
-                    shutil.copy(default_yaml_file, target_file)
-                    print(f"{filename} has been reset.")
-                else:
-                    print(f"{filename} was not reset.")
+            message = f"{filename} has been reset."
+            logger_fn(message)
+            if not non_interactive:
+                print(message)
+            summary.append(f"Reset {filename} -> {target_file}")
+            continue
+
+        with open(target_file, "r", encoding="utf-8") as file:
+            current_profile = file.read()
+
+        if current_profile not in historical_profiles:
+            if non_interactive:
+                proceed = confirm
             else:
-                shutil.copy(default_yaml_file, target_file)
-                print(f"{filename} has been reset.")
+                response = input(f"Would you like to reset/update {filename}? (y/n) ")
+                proceed = response.strip().lower() == "y"
+
+            if not proceed:
+                message = f"{filename} was not reset."
+                logger_fn(message)
+                if not non_interactive:
+                    print(message)
+                summary.append(message)
+                continue
+
+            try:
+                send2trash.send2trash(target_file)
+            except Exception:
+                logger.debug("Failed to move %s to trash.", target_file, exc_info=True)
+
+        shutil.copy(default_path, target_file)
+        message = f"{filename} has been reset."
+        logger_fn(message)
+        if not non_interactive:
+            print(message)
+        summary.append(f"Reset {filename} -> {target_file}")
+
+    return summary
 
 
 def get_default_profile(specific_default_profile):
@@ -753,16 +900,30 @@ def migrate_app_directory(old_dir, new_dir, profile_dir):
                     file.write("\nversion: 0.2.1  # Profile version (do not modify)")
 
 
-def migrate_user_app_directory():
+def migrate_user_app_directory(
+    *, log: Callable[[str], None] | None = None
+) -> list[str]:
+    logger_fn = log or logger.info
     user_version = determine_user_version()
+    summary: list[str] = []
 
     if user_version == "pre_0.2.0":
         old_dir = platformdirs.user_config_dir("Open Interpreter")
         migrate_app_directory(old_dir, oi_dir, profile_dir)
+        message = f"Migrated profiles from '{old_dir}' to '{oi_dir}'."
+        logger_fn(message)
+        summary.append(message)
 
     elif user_version == "0.2.0":
         old_dir = platformdirs.user_config_dir("Open Interpreter Terminal")
         migrate_app_directory(old_dir, oi_dir, profile_dir)
+        message = f"Migrated profiles from '{old_dir}' to '{oi_dir}'."
+        logger_fn(message)
+        summary.append(message)
+    else:
+        logger_fn("Profile directory is already on the latest format; no migration needed.")
+
+    return summary
 
 
 def write_key_to_profile(key, value):

--- a/src/open_interpreter/interfaces/terminal/start_terminal_interface.py
+++ b/src/open_interpreter/interfaces/terminal/start_terminal_interface.py
@@ -1,9 +1,11 @@
 import argparse
+import logging
 import os
 import sys
 import time
+from collections import defaultdict
 
-from importlib.metadata import version, PackageNotFoundError
+from importlib.metadata import version
 
 from open_interpreter.interfaces.terminal.contributing_conversations import (
     contribute_conversation_launch_logic,
@@ -11,9 +13,46 @@ from open_interpreter.interfaces.terminal.contributing_conversations import (
 )
 
 from .conversation_navigator import conversation_navigator
-from .profiles.profiles import open_storage_dir, profile, reset_profile
+from .profiles.profiles import (
+    migrate_user_app_directory,
+    open_storage_dir,
+    profile,
+    reset_profile,
+)
 from .utils.check_for_update import check_for_update
+from .utils.cli_overrides import capture_cli_overrides
+from .utils.session_header import display_session_header
 from .validate_llm_settings import validate_llm_settings
+
+from rich.console import Console
+from rich.table import Table
+from rich.text import Text
+
+
+logger = logging.getLogger(__name__)
+
+
+HELP_CATEGORY_STYLES = {
+    "Profiles & Sessions": "bold magenta",
+    "Model Configuration": "bold cyan",
+    "Execution & Safety": "bold green",
+    "Display & Interaction": "bold yellow",
+    "Connectivity & API": "bold blue",
+    "Accessibility": "bold white",
+    "Diagnostics & Debugging": "bold red",
+    "Community": "bold bright_magenta",
+}
+
+HELP_CATEGORY_ORDER = [
+    "Profiles & Sessions",
+    "Model Configuration",
+    "Execution & Safety",
+    "Display & Interaction",
+    "Connectivity & API",
+    "Accessibility",
+    "Diagnostics & Debugging",
+    "Community",
+]
 
 
 def start_terminal_interface(interpreter):
@@ -34,6 +73,8 @@ def start_terminal_interface(interpreter):
             "help_text": "name of profile. run `--profiles` to open profile directory",
             "type": str,
             "default": "default.yaml",
+            "category": "Profiles & Sessions",
+            "example": "interpreter --profile research.yaml",
         },
         {
             "name": "custom_instructions",
@@ -41,6 +82,8 @@ def start_terminal_interface(interpreter):
             "help_text": "custom instructions for the language model. will be appended to the system_message",
             "type": str,
             "attribute": {"object": interpreter, "attr_name": "custom_instructions"},
+            "category": "Model Configuration",
+            "example": "interpreter --custom_instructions \"Prefer python\"",
         },
         {
             "name": "system_message",
@@ -48,6 +91,8 @@ def start_terminal_interface(interpreter):
             "help_text": "(we don't recommend changing this) base prompt for the language model",
             "type": str,
             "attribute": {"object": interpreter, "attr_name": "system_message"},
+            "category": "Model Configuration",
+            "example": "interpreter --system_message path/to/prompt.txt",
         },
         {
             "name": "auto_run",
@@ -55,6 +100,8 @@ def start_terminal_interface(interpreter):
             "help_text": "automatically run generated code",
             "type": bool,
             "attribute": {"object": interpreter, "attr_name": "auto_run"},
+            "category": "Execution & Safety",
+            "example": "interpreter --auto_run",
         },
         {
             "name": "no_highlight_active_line",
@@ -62,7 +109,9 @@ def start_terminal_interface(interpreter):
             "help_text": "turn off active line highlighting in code blocks",
             "type": bool,
             "action": "store_true",
-            "default": False,  # Default to False, meaning highlighting is on by default
+            "default": False,
+            "category": "Display & Interaction",
+            "example": "interpreter --no_highlight_active_line",
         },
         {
             "name": "verbose",
@@ -70,6 +119,8 @@ def start_terminal_interface(interpreter):
             "help_text": "print detailed logs",
             "type": bool,
             "attribute": {"object": interpreter, "attr_name": "verbose"},
+            "category": "Diagnostics & Debugging",
+            "example": "interpreter --verbose",
         },
         {
             "name": "model",
@@ -77,6 +128,8 @@ def start_terminal_interface(interpreter):
             "help_text": "language model to use",
             "type": str,
             "attribute": {"object": interpreter.llm, "attr_name": "model"},
+            "category": "Model Configuration",
+            "example": "interpreter --model openai/gpt-4o-mini",
         },
         {
             "name": "temperature",
@@ -84,6 +137,8 @@ def start_terminal_interface(interpreter):
             "help_text": "optional temperature setting for the language model",
             "type": float,
             "attribute": {"object": interpreter.llm, "attr_name": "temperature"},
+            "category": "Model Configuration",
+            "example": "interpreter --temperature 0.2",
         },
         {
             "name": "llm_supports_vision",
@@ -92,6 +147,8 @@ def start_terminal_interface(interpreter):
             "type": bool,
             "action": argparse.BooleanOptionalAction,
             "attribute": {"object": interpreter.llm, "attr_name": "supports_vision"},
+            "category": "Model Configuration",
+            "example": "interpreter --llm_supports_vision",
         },
         {
             "name": "llm_supports_functions",
@@ -100,6 +157,8 @@ def start_terminal_interface(interpreter):
             "type": bool,
             "action": argparse.BooleanOptionalAction,
             "attribute": {"object": interpreter.llm, "attr_name": "supports_functions"},
+            "category": "Model Configuration",
+            "example": "interpreter --no-llm_supports_functions",
         },
         {
             "name": "context_window",
@@ -107,6 +166,8 @@ def start_terminal_interface(interpreter):
             "help_text": "optional context window size for the language model",
             "type": int,
             "attribute": {"object": interpreter.llm, "attr_name": "context_window"},
+            "category": "Model Configuration",
+            "example": "interpreter --context_window 32768",
         },
         {
             "name": "max_tokens",
@@ -114,6 +175,8 @@ def start_terminal_interface(interpreter):
             "help_text": "optional maximum number of tokens for the language model",
             "type": int,
             "attribute": {"object": interpreter.llm, "attr_name": "max_tokens"},
+            "category": "Model Configuration",
+            "example": "interpreter --max_tokens 2048",
         },
         {
             "name": "max_budget",
@@ -121,6 +184,8 @@ def start_terminal_interface(interpreter):
             "help_text": "optionally set the max budget (in USD) for your llm calls",
             "type": float,
             "attribute": {"object": interpreter.llm, "attr_name": "max_budget"},
+            "category": "Model Configuration",
+            "example": "interpreter --max_budget 1.25",
         },
         {
             "name": "api_base",
@@ -128,6 +193,8 @@ def start_terminal_interface(interpreter):
             "help_text": "optionally set the API base URL for your llm calls (this will override environment variables)",
             "type": str,
             "attribute": {"object": interpreter.llm, "attr_name": "api_base"},
+            "category": "Connectivity & API",
+            "example": "interpreter --api_base https://api.example.com",
         },
         {
             "name": "api_key",
@@ -135,6 +202,8 @@ def start_terminal_interface(interpreter):
             "help_text": "optionally set the API key for your llm calls (this will override environment variables)",
             "type": str,
             "attribute": {"object": interpreter.llm, "attr_name": "api_key"},
+            "category": "Connectivity & API",
+            "example": "interpreter --api_key sk-...",
         },
         {
             "name": "api_version",
@@ -142,6 +211,8 @@ def start_terminal_interface(interpreter):
             "help_text": "optionally set the API version for your llm calls (this will override environment variables)",
             "type": str,
             "attribute": {"object": interpreter.llm, "attr_name": "api_version"},
+            "category": "Connectivity & API",
+            "example": "interpreter --api_version 2024-05-01",
         },
         {
             "name": "max_output",
@@ -149,12 +220,16 @@ def start_terminal_interface(interpreter):
             "help_text": "optional maximum number of characters for code outputs",
             "type": int,
             "attribute": {"object": interpreter, "attr_name": "max_output"},
+            "category": "Execution & Safety",
+            "example": "interpreter --max_output 1200",
         },
         {
             "name": "loop",
             "help_text": "runs OI in a loop, requiring it to admit to completing/failing task",
             "type": bool,
             "attribute": {"object": interpreter, "attr_name": "loop"},
+            "category": "Execution & Safety",
+            "example": "interpreter --loop",
         },
         {
             "name": "disable_telemetry",
@@ -163,6 +238,8 @@ def start_terminal_interface(interpreter):
             "type": bool,
             "default": False,
             "attribute": {"object": interpreter, "attr_name": "disable_telemetry"},
+            "category": "Diagnostics & Debugging",
+            "example": "interpreter --disable_telemetry",
         },
         {
             "name": "offline",
@@ -170,6 +247,8 @@ def start_terminal_interface(interpreter):
             "help_text": "turns off all online features (except the language model, if it's hosted)",
             "type": bool,
             "attribute": {"object": interpreter, "attr_name": "offline"},
+            "category": "Connectivity & API",
+            "example": "interpreter --offline",
         },
         {
             "name": "speak_messages",
@@ -177,6 +256,8 @@ def start_terminal_interface(interpreter):
             "help_text": "(Mac only, experimental) use the applescript `say` command to read messages aloud",
             "type": bool,
             "attribute": {"object": interpreter, "attr_name": "speak_messages"},
+            "category": "Accessibility",
+            "example": "interpreter --speak_messages",
         },
         {
             "name": "safe_mode",
@@ -186,6 +267,8 @@ def start_terminal_interface(interpreter):
             "choices": ["off", "ask", "auto"],
             "default": "off",
             "attribute": {"object": interpreter, "attr_name": "safe_mode"},
+            "category": "Execution & Safety",
+            "example": "interpreter --safe_mode ask",
         },
         {
             "name": "debug",
@@ -193,12 +276,16 @@ def start_terminal_interface(interpreter):
             "help_text": "debug mode for open interpreter developers",
             "type": bool,
             "attribute": {"object": interpreter, "attr_name": "debug"},
+            "category": "Diagnostics & Debugging",
+            "example": "interpreter --debug",
         },
         {
             "name": "fast",
             "nickname": "f",
             "help_text": "runs `interpreter --model gpt-4o-mini` and asks OI to be extremely concise (shortcut for `interpreter --profile fast`)",
             "type": bool,
+            "category": "Profiles & Sessions",
+            "example": "interpreter --fast",
         },
         {
             "name": "multi_line",
@@ -206,73 +293,120 @@ def start_terminal_interface(interpreter):
             "help_text": "enable multi-line inputs starting and ending with ```",
             "type": bool,
             "attribute": {"object": interpreter, "attr_name": "multi_line"},
+            "category": "Display & Interaction",
+            "example": "interpreter --multi_line",
         },
         {
             "name": "local",
             "nickname": "l",
             "help_text": "setup a local model (shortcut for `interpreter --profile local`)",
             "type": bool,
+            "category": "Profiles & Sessions",
+            "example": "interpreter --local",
         },
         {
             "name": "codestral",
             "help_text": "shortcut for `interpreter --profile codestral`",
             "type": bool,
+            "category": "Profiles & Sessions",
+            "example": "interpreter --codestral",
         },
         {
             "name": "assistant",
             "help_text": "shortcut for `interpreter --profile assistant.py`",
             "type": bool,
+            "category": "Profiles & Sessions",
+            "example": "interpreter --assistant",
         },
         {
             "name": "llama3",
             "help_text": "shortcut for `interpreter --profile llama3`",
             "type": bool,
+            "category": "Profiles & Sessions",
+            "example": "interpreter --llama3",
         },
         {
             "name": "groq",
             "help_text": "shortcut for `interpreter --profile groq`",
             "type": bool,
+            "category": "Profiles & Sessions",
+            "example": "interpreter --groq",
         },
         {
             "name": "vision",
             "nickname": "vi",
             "help_text": "experimentally use vision for supported languages (shortcut for `interpreter --profile vision`)",
             "type": bool,
+            "category": "Profiles & Sessions",
+            "example": "interpreter --vision",
         },
         {
             "name": "os",
             "nickname": "os",
             "help_text": "experimentally let Open Interpreter control your mouse and keyboard (shortcut for `interpreter --profile os`)",
             "type": bool,
+            "category": "Profiles & Sessions",
+            "example": "interpreter --os",
         },
-        # Special commands
         {
             "name": "reset_profile",
             "help_text": "reset a profile file. run `--reset_profile` without an argument to reset all default profiles",
             "type": str,
             "default": "NOT_PROVIDED",
-            "nargs": "?",  # This means you can pass in nothing if you want
+            "nargs": "?",
+            "category": "Profiles & Sessions",
+            "example": "interpreter --reset_profile default.yaml",
         },
-        {"name": "profiles", "help_text": "opens profiles directory", "type": bool},
+        {
+            "name": "reset_profile_force",
+            "help_text": "reset profiles without prompts (use with --reset_profile)",
+            "type": bool,
+            "default": False,
+            "category": "Profiles & Sessions",
+            "example": "interpreter --reset_profile --reset_profile_force",
+        },
+        {
+            "name": "migrate_profiles",
+            "help_text": "migrate stored profiles to the latest format without prompts",
+            "type": bool,
+            "default": False,
+            "category": "Profiles & Sessions",
+            "example": "interpreter --migrate_profiles",
+        },
+        {
+            "name": "profiles",
+            "help_text": "opens profiles directory",
+            "type": bool,
+            "category": "Profiles & Sessions",
+            "example": "interpreter --profiles",
+        },
         {
             "name": "local_models",
             "help_text": "opens local models directory",
             "type": bool,
+            "category": "Profiles & Sessions",
+            "example": "interpreter --local_models",
         },
         {
             "name": "conversations",
             "help_text": "list conversations to resume",
             "type": bool,
+            "category": "Profiles & Sessions",
+            "example": "interpreter --conversations",
         },
         {
             "name": "server",
             "help_text": "start open interpreter as a server",
             "type": bool,
+            "category": "Connectivity & API",
+            "example": "interpreter --server",
         },
         {
             "name": "version",
             "help_text": "get Open Interpreter's version number",
             "type": bool,
+            "category": "Diagnostics & Debugging",
+            "example": "interpreter --version",
         },
         {
             "name": "contribute_conversation",
@@ -282,6 +416,8 @@ def start_terminal_interface(interpreter):
                 "object": interpreter,
                 "attr_name": "contribute_conversation",
             },
+            "category": "Community",
+            "example": "interpreter --contribute_conversation",
         },
         {
             "name": "plain",
@@ -292,12 +428,16 @@ def start_terminal_interface(interpreter):
                 "object": interpreter,
                 "attr_name": "plain_text_display",
             },
+            "category": "Display & Interaction",
+            "example": "interpreter --plain",
         },
         {
             "name": "stdin",
             "nickname": "s",
             "help_text": "Run OI in stdin mode",
             "type": bool,
+            "category": "Display & Interaction",
+            "example": "echo 'hello' | interpreter --stdin",
         },
     ]
 
@@ -336,13 +476,48 @@ def start_terminal_interface(interpreter):
 
     class CustomHelpParser(argparse.ArgumentParser):
         def print_help(self, *args, **kwargs):
-            super().print_help(*args, **kwargs)
-            special_help_message = '''
-Open Interpreter, 2024
+            console = Console()
+            console.print(Text("Open Interpreter", style="bold cyan"))
+            console.print(Text(self.format_usage().strip(), style="dim"))
+            console.print("")
 
-Use """ to write multi-line messages.
-            '''
-            print(special_help_message)
+            grouped_arguments = defaultdict(list)
+            for spec in arguments:
+                grouped_arguments[spec.get("category", "Other")].append(spec)
+
+            for category in HELP_CATEGORY_ORDER:
+                specs = grouped_arguments.get(category)
+                if not specs:
+                    continue
+
+                console.print(Text(category, style=HELP_CATEGORY_STYLES.get(category, "bold")))
+                table = Table(show_header=False, box=None, padding=(0, 1))
+
+                for spec in specs:
+                    flags = []
+                    nickname = spec.get("nickname")
+                    if nickname:
+                        flags.append(f"-{nickname}")
+                    flags.append(f"--{spec['name']}")
+
+                    help_text = spec["help_text"]
+                    example = spec.get("example")
+                    if example:
+                        help_text = f"{help_text} [dim](e.g. {example})[/dim]"
+
+                    table.add_row(f"[cyan]{', '.join(flags)}[/cyan]", help_text)
+
+                console.print(table)
+                console.print("")
+
+            console.print(
+                Text(
+                    "Tip: type '::' during a session to open the command palette.",
+                    style="dim",
+                )
+            )
+            console.print(Text("Use \"\"\" to write multi-line messages.", style="dim"))
+            console.print(Text("Open Interpreter, 2024", style="dim"))
 
     parser = CustomHelpParser(
         description="Open Interpreter", usage="%(prog)s [options]"
@@ -384,6 +559,7 @@ Use """ to write multi-line messages.
             )
 
     args, unknown_args = parser.parse_known_args()
+    cli_overrides, attribute_map = capture_cli_overrides(interpreter, args, arguments)
 
     # handle unknown arguments
     if unknown_args:
@@ -394,6 +570,15 @@ Use """ to write multi-line messages.
         )
         sys.exit(1)
 
+    if args.reset_profile_force and args.reset_profile == "NOT_PROVIDED":
+        print("`--reset_profile_force` must be used together with `--reset_profile`.")
+        sys.exit(1)
+
+    if args.migrate_profiles:
+        summary = migrate_user_app_directory(log=logger.info)
+        _print_operations_summary("Profile migration", summary)
+        return
+
     if args.profiles:
         open_storage_dir("profiles")
         return
@@ -402,10 +587,15 @@ Use """ to write multi-line messages.
         open_storage_dir("models")
         return
 
-    if args.reset_profile is not None and args.reset_profile != "NOT_PROVIDED":
-        reset_profile(
-            args.reset_profile
-        )  # This will be None if they just ran `--reset_profile`
+    if args.reset_profile != "NOT_PROVIDED":
+        summary = reset_profile(
+            args.reset_profile,
+            non_interactive=args.reset_profile_force,
+            confirm=args.reset_profile_force,
+            log=logger.info,
+        )
+        if args.reset_profile_force:
+            _print_operations_summary("Profile reset", summary)
         return
 
     if args.version:
@@ -481,6 +671,10 @@ Use """ to write multi-line messages.
         or args.disable_telemetry
     )
 
+    interpreter._cli_overrides = cli_overrides
+    interpreter._cli_attribute_map = attribute_map
+    interpreter._command_palette_enabled = not args.stdin
+
     ### Set some helpful settings we know are likely to be true
 
     if interpreter.llm.model == "gpt-4" or interpreter.llm.model == "openai/gpt-4":
@@ -514,6 +708,9 @@ Use """ to write multi-line messages.
             interpreter.llm.max_tokens = 4096
         if interpreter.llm.supports_functions is None:
             interpreter.llm.supports_functions = True
+
+    if not args.stdin:
+        display_session_header(interpreter)
 
     ### Check for update
 
@@ -590,6 +787,19 @@ def set_attributes(args, arguments):
                         print(
                             f"Setting attribute {attr_dict['attr_name']} on {attr_dict['object'].__class__.__name__.lower()} to '{argument_value}'..."
                         )
+
+
+def _print_operations_summary(title: str, operations):
+    if operations is None:
+        return
+
+    if not operations:
+        print(f"{title}: No changes were necessary.")
+        return
+
+    print(title)
+    for line in operations:
+        print(f" - {line}")
 
 
 def get_argument_dictionary(arguments: list[dict], key: str) -> dict:

--- a/src/open_interpreter/interfaces/terminal/terminal_interface.py
+++ b/src/open_interpreter/interfaces/terminal/terminal_interface.py
@@ -21,6 +21,7 @@ from ..core.utils.system_debug_info import system_info
 from ..core.utils.truncate_output import truncate_output
 from .components.code_block import CodeBlock
 from .components.message_block import MessageBlock
+from .command_palette import open_command_palette
 from .magic_commands import handle_magic_command
 from .utils.check_for_package import check_for_package
 from .utils.cli_input import cli_input
@@ -113,6 +114,13 @@ def terminal_interface(interpreter, message):
         if isinstance(message, str):
             # This is for the terminal interface being used as a CLI — messages are strings.
             # This won't fire if they're in the python package, display=True, and they passed in an array of messages (for example).
+
+            if message.strip() == "::":
+                if getattr(interpreter, "_command_palette_enabled", True):
+                    open_command_palette(interpreter)
+                else:
+                    interpreter.display_message("> Command palette is not available in this mode.")
+                continue
 
             if message == "":
                 # Ignore empty messages when user presses enter without typing anything

--- a/src/open_interpreter/interfaces/terminal/utils/cli_overrides.py
+++ b/src/open_interpreter/interfaces/terminal/utils/cli_overrides.py
@@ -1,0 +1,66 @@
+"""Helpers for capturing and reapplying CLI override values."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, Tuple
+
+
+def capture_cli_overrides(
+    interpreter: Any,
+    args: Any,
+    argument_specs: Iterable[Dict[str, Any]],
+) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    """Return CLI overrides and attribute targets for later reapplication."""
+
+    overrides: Dict[str, Any] = {}
+    attribute_map: Dict[str, Any] = {}
+    values = vars(args)
+
+    for spec in argument_specs:
+        attribute_spec = spec.get("attribute")
+        if not attribute_spec:
+            continue
+
+        target_object = attribute_spec.get("object")
+        attribute_name = attribute_spec.get("attr_name")
+
+        if attribute_name is None:
+            continue
+
+        if target_object is interpreter:
+            attribute_map[spec["name"]] = ("interpreter", attribute_name)
+        elif target_object is interpreter.llm:
+            attribute_map[spec["name"]] = ("llm", attribute_name)
+        else:
+            attribute_map[spec["name"]] = ("object", target_object, attribute_name)
+
+        value = values.get(spec["name"])
+        default = spec.get("default")
+
+        if value is None:
+            continue
+
+        if value != default:
+            overrides[spec["name"]] = value
+
+    return overrides, attribute_map
+
+
+def apply_cli_overrides(interpreter: Any) -> None:
+    """Reapply stored CLI overrides to the interpreter after profile changes."""
+
+    overrides: Dict[str, Any] = getattr(interpreter, "_cli_overrides", {})
+    attribute_map: Dict[str, Any] = getattr(interpreter, "_cli_attribute_map", {})
+
+    for name, value in overrides.items():
+        target_spec = attribute_map.get(name)
+        if not target_spec:
+            continue
+
+        if target_spec[0] == "interpreter":
+            setattr(interpreter, target_spec[1], value)
+        elif target_spec[0] == "llm":
+            setattr(interpreter.llm, target_spec[1], value)
+        elif target_spec[0] == "object":
+            _, obj, attr_name = target_spec
+            setattr(obj, attr_name, value)

--- a/src/open_interpreter/interfaces/terminal/utils/session_header.py
+++ b/src/open_interpreter/interfaces/terminal/utils/session_header.py
@@ -1,0 +1,121 @@
+"""Utilities for rendering the terminal session header."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from rich.console import Console
+from rich.panel import Panel
+from rich.text import Text
+
+console = Console()
+
+
+def _format_temperature(value: Any) -> str:
+    if value is None:
+        return "default"
+    try:
+        return f"{float(value):.2f}"
+    except (TypeError, ValueError):
+        return str(value)
+
+
+def _format_source(source: str | None) -> str:
+    mapping = {
+        "default": "default",
+        "user": "custom",
+        "remote": "remote",
+        "custom": "custom",
+    }
+    return mapping.get(source or "", source or "unknown")
+
+
+def _collect_session_metadata(interpreter: Any) -> dict[str, Any]:
+    profile_meta = getattr(interpreter, "profile_metadata", {}) or {}
+    temperature = getattr(getattr(interpreter, "llm", object()), "temperature", None)
+
+    return {
+        "profile_name": profile_meta.get("name", "default.yaml"),
+        "profile_source": profile_meta.get("source"),
+        "profile_version": profile_meta.get("version"),
+        "profile_path": profile_meta.get("path"),
+        "model": getattr(getattr(interpreter, "llm", object()), "model", "unknown"),
+        "temperature": _format_temperature(temperature),
+        "auto_run": "on" if getattr(interpreter, "auto_run", False) else "off",
+        "safe_mode": getattr(interpreter, "safe_mode", "off"),
+        "custom_instructions": bool(getattr(interpreter, "custom_instructions", "")),
+        "plain_text": getattr(interpreter, "plain_text_display", False),
+        "palette_enabled": getattr(interpreter, "_command_palette_enabled", True),
+    }
+
+
+def display_session_header(interpreter: Any) -> None:
+    """Render the session header with active profile metadata."""
+
+    metadata = _collect_session_metadata(interpreter)
+
+    profile_label = _format_source(metadata["profile_source"])
+    version_label = metadata["profile_version"]
+    profile_path = metadata["profile_path"]
+
+    if metadata["plain_text"]:
+        print(
+            f"Session profile: {metadata['profile_name']} ({profile_label})"
+            + (f" v{version_label}" if version_label else "")
+        )
+        if profile_path:
+            print(f"Path: {profile_path}")
+        print(
+            "Model: {model} | Temp: {temp} | Auto-run: {auto} | Safe mode: {safe}".format(
+                model=metadata["model"],
+                temp=metadata["temperature"],
+                auto=metadata["auto_run"],
+                safe=metadata["safe_mode"],
+            )
+        )
+        if metadata["custom_instructions"]:
+            print("Custom instructions: enabled")
+        if metadata["palette_enabled"]:
+            print("Hint: type '::' during the session to open the command palette.")
+        print("")
+        return
+
+    profile_line = Text()
+    profile_line.append(metadata["profile_name"], style="bold cyan")
+    profile_line.append(f" • {profile_label}", style="dim")
+    if version_label:
+        profile_line.append(f" • v{version_label}", style="dim")
+    if profile_path:
+        profile_line.append(f"\n{profile_path}", style="dim")
+
+    model_line = Text()
+    model_line.append(metadata["model"], style="bold white")
+    model_line.append(
+        f" • temp {metadata['temperature']} • auto-run {metadata['auto_run']} • safe mode {metadata['safe_mode']}",
+        style="dim",
+    )
+
+    details_line = Text()
+    details_line.append(
+        "Custom instructions: ",
+        style="dim",
+    )
+    details_line.append(
+        "enabled" if metadata["custom_instructions"] else "disabled",
+        style="bold",
+    )
+    if metadata["palette_enabled"]:
+        details_line.append(
+            " • type '::' to open the command palette",
+            style="dim",
+        )
+
+    body = Text()
+    body.append(profile_line)
+    body.append("\n")
+    body.append(model_line)
+    body.append("\n")
+    body.append(details_line)
+
+    panel = Panel(body, border_style="cyan", title="Session")
+    console.print(panel)


### PR DESCRIPTION
## Summary
- group terminal CLI options by category with color-coded help output and inline examples
- surface active profile metadata in a rich session header and expose a command palette for runtime profile switching
- support non-interactive profile resets/migrations with logging, reusable CLI overrides, and profile metadata tracking

## Testing
- pytest tests/interfaces/terminal -k profiles *(fails: directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d6389696f0832e88c422210ff4413c