### PR TITLE
Enhance terminal theming and transcript exports

### DIFF
--- a/interpreter/terminal_interface/components/theme.py
+++ b/interpreter/terminal_interface/components/theme.py
@@ -1,0 +1,3 @@
+"""Compatibility shim for :mod:`open_interpreter.interfaces.terminal.components.theme`."""
+
+from open_interpreter.interfaces.terminal.components.theme import *  # noqa: F401,F403

--- a/src/open_interpreter/interfaces/terminal/components/code_block.py
+++ b/src/open_interpreter/interfaces/terminal/components/code_block.py
@@ -1,10 +1,13 @@
 from rich.box import MINIMAL
 from rich.console import Group
 from rich.panel import Panel
+from rich.padding import Padding
 from rich.syntax import Syntax
 from rich.table import Table
+from rich.text import Text
 
 from .base_block import BaseBlock
+from .theme import MATERIAL_SYNTAX_THEME, MATERIAL_TOKENS, STANDARD_MARGIN
 
 
 class CodeBlock(BaseBlock):
@@ -41,9 +44,14 @@ class CodeBlock(BaseBlock):
 
         # Create a table for the code
         code_table = Table(
-            show_header=False, show_footer=False, box=None, padding=0, expand=True
+            show_header=False,
+            show_footer=False,
+            box=None,
+            padding=(0, 0),
+            expand=True,
+            pad_edge=False,
         )
-        code_table.add_column()
+        code_table.add_column(no_wrap=True)
 
         # Add cursor only if active line highliting is true
         if cursor and (
@@ -63,35 +71,63 @@ class CodeBlock(BaseBlock):
             ):
                 # This is the active line, print it with a white background
                 syntax = Syntax(
-                    line, self.language, theme="bw", line_numbers=False, word_wrap=True
+                    line,
+                    self.language,
+                    theme=MATERIAL_SYNTAX_THEME,
+                    line_numbers=False,
+                    word_wrap=True,
                 )
-                code_table.add_row(syntax, style="black on white")
+                highlight_style = (
+                    f"{MATERIAL_TOKENS['on_primary']} on {MATERIAL_TOKENS['primary']}"
+                )
+                code_table.add_row(syntax, style=highlight_style)
             else:
                 # This is not the active line, print it normally
                 syntax = Syntax(
                     line,
                     self.language,
-                    theme="monokai",
+                    theme=MATERIAL_SYNTAX_THEME,
                     line_numbers=False,
                     word_wrap=True,
                 )
                 code_table.add_row(syntax)
 
         # Create a panel for the code
-        code_panel = Panel(code_table, box=MINIMAL, style="on #272722")
+        code_panel = Panel(
+            code_table,
+            box=MINIMAL,
+            style=f"on {MATERIAL_TOKENS['code_surface']}",
+            border_style=MATERIAL_TOKENS["code_border"],
+            padding=(1, 2),
+        )
 
         # Create a panel for the output (if there is any)
         if self.output == "" or self.output == "None":
-            output_panel = ""
+            output_panel = None
         else:
-            output_panel = Panel(self.output, box=MINIMAL, style="#FFFFFF on #3b3b37")
+            output_text = Text(
+                self.output,
+                style=f"{MATERIAL_TOKENS['on_surface']} on {MATERIAL_TOKENS['output_surface']}",
+            )
+            output_panel = Panel(
+                output_text,
+                box=MINIMAL,
+                style=f"on {MATERIAL_TOKENS['output_surface']}",
+                border_style=MATERIAL_TOKENS["output_border"],
+                padding=(1, 2),
+                title="Console output",
+                title_align="left",
+            )
 
         # Create a group with the code table and output panel
-        group_items = [code_panel, output_panel]
-        if self.margin_top:
-            # This adds some space at the top. Just looks good!
-            group_items = [""] + group_items
+        group_items = [code_panel]
+        if output_panel:
+            group_items.append(output_panel)
+
         group = Group(*group_items)
+
+        if self.margin_top:
+            group = Padding(group, STANDARD_MARGIN)
 
         # Update the live display
         self.live.update(group)

--- a/src/open_interpreter/interfaces/terminal/components/message_block.py
+++ b/src/open_interpreter/interfaces/terminal/components/message_block.py
@@ -1,10 +1,41 @@
+from __future__ import annotations
+
 import re
+from dataclasses import dataclass
+from typing import Iterable, List, Literal, Optional
 
 from rich.box import MINIMAL
+from rich.console import Group
 from rich.markdown import Markdown
 from rich.panel import Panel
+from rich.padding import Padding
+from rich.syntax import Syntax
+from rich.text import Text
 
 from .base_block import BaseBlock
+from .theme import MATERIAL_SYNTAX_THEME, MATERIAL_TOKENS, STANDARD_MARGIN, callout_accent
+
+__all__ = [
+    "MessageBlock",
+    "CalloutMetadata",
+    "MessageSegment",
+    "parse_message_segments",
+]
+
+
+@dataclass
+class CalloutMetadata:
+    callout_type: str
+    title: str
+    body: str
+
+
+@dataclass
+class MessageSegment:
+    kind: Literal["markdown", "code", "callout"]
+    text: str
+    language: Optional[str] = None
+    callout: Optional[CalloutMetadata] = None
 
 
 class MessageBlock(BaseBlock):
@@ -13,37 +44,164 @@ class MessageBlock(BaseBlock):
 
         self.type = "message"
         self.message = ""
+        self.margin_top = False
 
     def refresh(self, cursor=True):
-        # De-stylize any code blocks in markdown,
-        # to differentiate from our Code Blocks
-        content = textify_markdown_code_blocks(self.message)
+        segments = parse_message_segments(self.message)
+        renderables = list(_render_segments(segments))
 
         if cursor:
-            content += "●"
+            renderables.append(Text("●", style=MATERIAL_TOKENS["accent"]))
 
-        markdown = Markdown(content.strip())
-        panel = Panel(markdown, box=MINIMAL)
-        self.live.update(panel)
+        if not renderables:
+            renderables = [Text("")]
+
+        body = Group(*renderables) if len(renderables) > 1 else renderables[0]
+        panel = Panel(
+            body,
+            box=MINIMAL,
+            padding=(1, 2),
+            border_style=MATERIAL_TOKENS["outline"],
+            style=f"on {MATERIAL_TOKENS['surface']}",
+        )
+
+        renderable = panel
+        if self.margin_top:
+            renderable = Padding(panel, STANDARD_MARGIN)
+
+        self.live.update(renderable)
         self.live.refresh()
 
 
-def textify_markdown_code_blocks(text):
-    """
-    To distinguish CodeBlocks from markdown code, we simply turn all markdown code
-    (like '```python...') into text code blocks ('```text') which makes the code black and white.
-    """
-    replacement = "```text"
-    lines = text.split("\n")
-    inside_code_block = False
+def parse_message_segments(text: str) -> List[MessageSegment]:
+    """Split a message into semantic segments for rendering and exports."""
 
-    for i in range(len(lines)):
-        # If the line matches ``` followed by optional language specifier
-        if re.match(r"^```(\w*)$", lines[i].strip()):
-            inside_code_block = not inside_code_block
+    lines = text.splitlines()
+    segments: List[MessageSegment] = []
+    buffer: List[str] = []
+    i = 0
 
-            # If we just entered a code block, replace the marker
-            if inside_code_block:
-                lines[i] = replacement
+    def flush_buffer():
+        if buffer:
+            segments.append(MessageSegment("markdown", "\n".join(buffer)))
+            buffer.clear()
 
-    return "\n".join(lines)
+    while i < len(lines):
+        line = lines[i]
+
+        stripped = line.strip()
+
+        if stripped.startswith("```"):
+            flush_buffer()
+            language = stripped[3:].strip()
+            code_lines: List[str] = []
+            i += 1
+            while i < len(lines) and not lines[i].strip().startswith("```"):
+                code_lines.append(lines[i])
+                i += 1
+            if i < len(lines) and lines[i].strip().startswith("```"):
+                i += 1
+            segments.append(
+                MessageSegment(
+                    "code",
+                    "\n".join(code_lines),
+                    language=language or None,
+                )
+            )
+            continue
+
+        if stripped.startswith(">"):
+            flush_buffer()
+            callout_lines: List[str] = []
+            while i < len(lines) and lines[i].lstrip().startswith(">"):
+                callout_lines.append(lines[i])
+                i += 1
+            segments.append(
+                MessageSegment(
+                    "callout",
+                    "\n".join(callout_lines),
+                    callout=_parse_callout(callout_lines),
+                )
+            )
+            continue
+
+        buffer.append(line)
+        i += 1
+
+    flush_buffer()
+    return segments
+
+
+def _render_segments(segments: Iterable[MessageSegment]):
+    for segment in segments:
+        if segment.kind == "markdown":
+            content = segment.text.strip("\n")
+            if content:
+                yield Markdown(content, code_theme=MATERIAL_SYNTAX_THEME)
+            continue
+
+        if segment.kind == "code":
+            language = segment.language or "text"
+            label = Text(
+                f"Code snippet ({language})",
+                style=MATERIAL_TOKENS["on_surface_variant"],
+            )
+            syntax = Syntax(
+                segment.text,
+                language,
+                theme=MATERIAL_SYNTAX_THEME,
+                line_numbers=False,
+                word_wrap=True,
+            )
+            yield Panel(
+                Group(label, syntax),
+                box=MINIMAL,
+                padding=(1, 2),
+                border_style=MATERIAL_TOKENS["outline_variant"],
+                style=f"on {MATERIAL_TOKENS['surface_variant']}",
+            )
+            continue
+
+        if segment.kind == "callout" and segment.callout:
+            meta = segment.callout
+            heading = meta.title or meta.callout_type
+            label = Text(
+                f"{meta.callout_type} callout",
+                style=callout_accent(meta.callout_type),
+            )
+            body_text = meta.body.strip()
+            body_renderable = (
+                Markdown(body_text, code_theme=MATERIAL_SYNTAX_THEME)
+                if body_text
+                else Text("")
+            )
+            yield Panel(
+                Group(label, body_renderable),
+                title=heading,
+                title_align="left",
+                box=MINIMAL,
+                padding=(1, 2),
+                border_style=callout_accent(meta.callout_type),
+                style=f"on {MATERIAL_TOKENS['surface_variant']}",
+            )
+            continue
+
+
+def _parse_callout(lines: Iterable[str]) -> CalloutMetadata:
+    cleaned = [re.sub(r"^>+\s?", "", line).rstrip() for line in lines]
+    if not cleaned:
+        return CalloutMetadata(callout_type="Note", title="", body="")
+
+    first_line = cleaned[0]
+    match = re.match(r"\[!(?P<type>[\w-]+)\]\s*(?P<title>.*)", first_line)
+    callout_type = "Note"
+    title = ""
+    body_lines = cleaned
+
+    if match:
+        callout_type = match.group("type").title()
+        title = match.group("title").strip()
+        body_lines = cleaned[1:]
+
+    body = "\n".join(body_lines).strip()
+    return CalloutMetadata(callout_type=callout_type or "Note", title=title, body=body)

--- a/src/open_interpreter/interfaces/terminal/components/theme.py
+++ b/src/open_interpreter/interfaces/terminal/components/theme.py
@@ -1,0 +1,48 @@
+"""Shared visual tokens for the terminal interface components.
+
+The palette is inspired by Material 3's dark theme so that code and
+message blocks share a consistent visual language regardless of where
+they are rendered.
+"""
+from __future__ import annotations
+
+from typing import Dict
+
+MATERIAL_TOKENS: Dict[str, str] = {
+    "surface": "#1C1B1F",
+    "surface_variant": "#2A2734",
+    "on_surface": "#E6E1E5",
+    "on_surface_variant": "#CAC4D0",
+    "outline": "#49454F",
+    "outline_variant": "#625B71",
+    "primary": "#D0BCFF",
+    "on_primary": "#381E72",
+    "code_surface": "#1F1A2B",
+    "code_border": "#4A4458",
+    "output_surface": "#221F2F",
+    "output_border": "#4A4458",
+    "accent": "#D0BCFF",
+    "warning": "#F2B8B5",
+    "info": "#80CBC4",
+    "success": "#C5E1A5",
+}
+
+MATERIAL_SYNTAX_THEME = "material"
+
+STANDARD_MARGIN = (1, 0, 0, 0)
+
+
+_CALLOUT_COLOR_MAP = {
+    "note": MATERIAL_TOKENS["accent"],
+    "info": MATERIAL_TOKENS["info"],
+    "tip": MATERIAL_TOKENS["success"],
+    "success": MATERIAL_TOKENS["success"],
+    "warning": MATERIAL_TOKENS["warning"],
+    "important": MATERIAL_TOKENS["warning"],
+    "caution": MATERIAL_TOKENS["warning"],
+}
+
+
+def callout_accent(callout_type: str) -> str:
+    """Return the accent color for a callout."""
+    return _CALLOUT_COLOR_MAP.get(callout_type.lower(), MATERIAL_TOKENS["outline_variant"])

--- a/src/open_interpreter/interfaces/terminal/magic_commands.py
+++ b/src/open_interpreter/interfaces/terminal/magic_commands.py
@@ -153,8 +153,14 @@ def handle_save_message(self, json_path):
         json_path = "messages.json"
     if not json_path.endswith(".json"):
         json_path += ".json"
-    with open(json_path, "w") as f:
-        json.dump(self.messages, f, indent=2)
+    payload: str
+    if hasattr(self, "transcript_as_json"):
+        payload = self.transcript_as_json()
+    else:
+        payload = json.dumps(self.messages, indent=2)
+
+    with open(json_path, "w", encoding="utf-8") as f:
+        f.write(payload)
 
     self.display_message(f"> messages json export to {os.path.abspath(json_path)}")
 
@@ -307,7 +313,11 @@ def markdown(self, export_path: str):
     if not export_path:
         export_path = get_downloads_path() + f"/{self.conversation_filename[:-4]}md"
 
-    export_to_markdown(self.messages, export_path)
+    markdown_text = None
+    if hasattr(self, "transcript_as_markdown"):
+        markdown_text = self.transcript_as_markdown()
+
+    export_to_markdown(self.messages, export_path, content=markdown_text)
 
 
 def handle_magic_command(self, user_input):

--- a/src/open_interpreter/interfaces/terminal/terminal_interface.py
+++ b/src/open_interpreter/interfaces/terminal/terminal_interface.py
@@ -8,6 +8,7 @@ try:
 except ImportError:
     pass
 
+import json
 import os
 import platform
 import random
@@ -15,12 +16,13 @@ import re
 import subprocess
 import tempfile
 import time
+from typing import Any, Dict, List, Optional
 
 from ..core.utils.scan_code import scan_code
 from ..core.utils.system_debug_info import system_info
 from ..core.utils.truncate_output import truncate_output
 from .components.code_block import CodeBlock
-from .components.message_block import MessageBlock
+from .components.message_block import MessageBlock, MessageSegment, parse_message_segments
 from .magic_commands import handle_magic_command
 from .utils.check_for_package import check_for_package
 from .utils.cli_input import cli_input
@@ -71,6 +73,14 @@ def terminal_interface(interpreter, message):
             interpreter_intro_message.append("Press `CTRL-C` to exit.")
 
         interpreter.display_message("\n\n".join(interpreter_intro_message) + "\n")
+
+    interpreter.get_live_transcript_blocks = lambda: build_transcript_blocks(
+        interpreter.messages
+    )
+    interpreter.transcript_as_json = lambda: transcript_to_json(interpreter.messages)
+    interpreter.transcript_as_markdown = lambda: transcript_to_markdown(
+        interpreter.messages
+    )
 
     if message:
         interactive = False
@@ -539,3 +549,209 @@ def terminal_interface(interpreter, message):
             if interpreter.debug:
                 system_info(interpreter)
             raise
+
+
+def build_transcript_blocks(messages: List[dict]) -> List[Dict[str, Any]]:
+    """Generate a structured representation of the live transcript."""
+
+    blocks: List[Dict[str, Any]] = []
+    active_code_block: Optional[Dict[str, Any]] = None
+
+    def finalize_code_block():
+        nonlocal active_code_block
+        if not active_code_block:
+            return
+
+        output_lines = [line for line in active_code_block.pop("output", []) if line]
+        active_code_block["console"] = "\n".join(output_lines).strip()
+        blocks.append(active_code_block)
+        active_code_block = None
+
+    for message in messages:
+        block_type = message.get("type")
+        role = message.get("role", "assistant")
+        fmt = message.get("format")
+        content = message.get("content", "")
+
+        if block_type == "code":
+            finalize_code_block()
+            active_code_block = {
+                "role": role,
+                "block_type": "code",
+                "language": fmt or "text",
+                "code": content,
+                "output": [],
+                "semantic_label": _semantic_label_for_code(role, fmt),
+            }
+            continue
+
+        if block_type == "console" and fmt in (None, "output"):
+            if active_code_block:
+                active_code_block.setdefault("output", []).append(content)
+                continue
+            blocks.append(
+                {
+                    "role": role,
+                    "block_type": "console",
+                    "format": fmt,
+                    "content": content,
+                    "semantic_label": _semantic_label_for_console(role, fmt),
+                }
+            )
+            continue
+
+        finalize_code_block()
+
+        if block_type == "message":
+            segments = [
+                _segment_to_export(segment)
+                for segment in parse_message_segments(content or "")
+            ]
+            blocks.append(
+                {
+                    "role": role,
+                    "block_type": "message",
+                    "segments": segments,
+                    "semantic_label": f"{role.title()} message",
+                }
+            )
+            continue
+
+        if block_type:
+            blocks.append(
+                {
+                    "role": role,
+                    "block_type": block_type,
+                    "format": fmt,
+                    "content": content,
+                    "semantic_label": _semantic_label_for_misc(role, block_type, fmt),
+                }
+            )
+
+    finalize_code_block()
+    return blocks
+
+
+def transcript_to_json(messages: List[dict]) -> str:
+    """Return the live transcript as formatted JSON."""
+
+    blocks = build_transcript_blocks(messages)
+    return json.dumps(blocks, indent=2, ensure_ascii=False)
+
+
+def transcript_to_markdown(messages: List[dict]) -> str:
+    """Render the live transcript in Markdown with semantic labels."""
+
+    blocks = build_transcript_blocks(messages)
+    lines: List[str] = []
+
+    def ensure_blank_line():
+        if lines and lines[-1] != "":
+            lines.append("")
+
+    for block in blocks:
+        ensure_blank_line()
+        lines.append(f"### {block['semantic_label']}")
+        lines.append("")
+
+        if block["block_type"] == "message":
+            for segment in block.get("segments", []):
+                kind = segment.get("kind")
+
+                if kind == "markdown":
+                    text = segment.get("text", "").strip("\n")
+                    if text:
+                        lines.append(text)
+                        lines.append("")
+                    continue
+
+                if kind == "code":
+                    language = segment.get("language", "text")
+                    snippet = segment.get("text", "")
+                    lines.append(f"**Code snippet ({language})**")
+                    lines.append(f"```{language}\n{snippet.rstrip()}\n```")
+                    lines.append("")
+                    continue
+
+                if kind == "callout":
+                    callout_type = segment.get("callout_type", "Note")
+                    title = segment.get("title", "")
+                    header = f"> [!{callout_type.upper()}]"
+                    if title:
+                        header += f" {title}"
+                    lines.append(header)
+                    body = segment.get("text", "")
+                    if body:
+                        for callout_line in body.splitlines():
+                            lines.append(f"> {callout_line}")
+                    lines.append("")
+                    continue
+
+            continue
+
+        if block["block_type"] == "code":
+            language = block.get("language", "text")
+            code = block.get("code", "")
+            lines.append(f"```{language}\n{code.rstrip()}\n```")
+            console = block.get("console", "")
+            if console:
+                lines.append("")
+                lines.append("> Console output")
+                for output_line in console.splitlines():
+                    lines.append(f"> {output_line}")
+            lines.append("")
+            continue
+
+        content = block.get("content", "")
+        if content:
+            lines.append(content)
+            lines.append("")
+
+    markdown = "\n".join(lines).strip()
+    return f"{markdown}\n" if markdown else ""
+
+
+def _segment_to_export(segment: MessageSegment) -> Dict[str, Any]:
+    if segment.kind == "code":
+        language = segment.language or "text"
+        return {
+            "kind": "code",
+            "language": language,
+            "text": segment.text,
+            "semantic_label": f"Code snippet in {language}",
+        }
+
+    if segment.kind == "callout" and segment.callout:
+        meta = segment.callout
+        return {
+            "kind": "callout",
+            "callout_type": meta.callout_type,
+            "title": meta.title,
+            "text": meta.body,
+            "semantic_label": f"{meta.callout_type} callout",
+        }
+
+    return {
+        "kind": "markdown",
+        "text": segment.text,
+        "semantic_label": "Markdown content",
+    }
+
+
+def _semantic_label_for_code(role: str, language: Optional[str]) -> str:
+    language_name = language or "plain text"
+    role_name = role.title() if role else "Assistant"
+    return f"{role_name} code execution ({language_name})"
+
+
+def _semantic_label_for_console(role: str, fmt: Optional[str]) -> str:
+    role_name = role.title() if role else "Assistant"
+    channel = fmt or "output"
+    return f"{role_name} console {channel}"
+
+
+def _semantic_label_for_misc(role: str, block_type: str, fmt: Optional[str]) -> str:
+    role_name = role.title() if role else "Assistant"
+    if fmt:
+        return f"{role_name} {block_type} ({fmt})"
+    return f"{role_name} {block_type}"

--- a/src/open_interpreter/interfaces/terminal/utils/export_to_markdown.py
+++ b/src/open_interpreter/interfaces/terminal/utils/export_to_markdown.py
@@ -1,6 +1,11 @@
-def export_to_markdown(messages: list[dict], export_path: str):
-    markdown = messages_to_markdown(messages)
-    with open(export_path, 'w') as f:
+from typing import Optional
+
+
+def export_to_markdown(
+    messages: list[dict], export_path: str, content: Optional[str] = None
+):
+    markdown = content if content is not None else messages_to_markdown(messages)
+    with open(export_path, "w", encoding="utf-8") as f:
         f.write(markdown)
     print(f"Exported current conversation to {export_path}")
 


### PR DESCRIPTION
## Summary
- normalize code block rendering with shared Material-inspired tokens and margin padding
- parse assistant message markdown into semantic segments for accessible rendering of inline snippets and callouts
- expose live transcript serialization for JSON/Markdown exports and use it when saving conversations

## Testing
- python -m compileall src/open_interpreter/interfaces/terminal

------
https://chatgpt.com/codex/tasks/task_e_68d6388b5064832e834615acd2b698a8