### PR TITLE
Add notifier, automation events, and configurable TTS settings

### DIFF
--- a/src/open_interpreter/core/computer/computer.py
+++ b/src/open_interpreter/core/computer/computer.py
@@ -1,5 +1,6 @@
 import inspect
 import json
+from typing import Any, Dict, Optional
 
 from open_interpreter.capabilities import capability_registry
 
@@ -117,6 +118,40 @@ Do not import the computer module, or any of its sub-modules. They are already i
                 provider=tool,
                 description=description,
             )
+
+    def emit_automation_event(
+        self,
+        action: str,
+        description: str,
+        *,
+        title: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Forward structured automation events to the interpreter."""
+
+        interpreter = getattr(self, "interpreter", None)
+        if not interpreter or not hasattr(interpreter, "log_automation_event"):
+            return
+
+        event_title = title or action.replace(".", " ").title()
+
+        # Ensure metadata is JSON-serialisable where possible
+        safe_metadata: Optional[Dict[str, Any]] = None
+        if metadata:
+            safe_metadata = {}
+            for key, value in metadata.items():
+                try:
+                    json.dumps(value)
+                    safe_metadata[key] = value
+                except (TypeError, ValueError):
+                    safe_metadata[key] = str(value)
+
+        interpreter.log_automation_event(
+            event_title,
+            description,
+            action=action,
+            metadata=safe_metadata,
+        )
 
     def _get_all_computer_tools_signature_and_description(self):
         """

--- a/src/open_interpreter/core/computer/display/display.py
+++ b/src/open_interpreter/core/computer/display/display.py
@@ -118,6 +118,22 @@ class Display:
         :param combine_screens: If True, a collage of all display screens will be returned. Otherwise, a list of display screens will be returned.
         """
 
+        description = (
+            "Capturing active application"
+            if active_app_only and quadrant is None
+            else "Capturing screen"
+        )
+        self.computer.emit_automation_event(
+            "computer.display.screenshot",
+            description,
+            metadata={
+                "screen": screen,
+                "quadrant": quadrant,
+                "active_app_only": active_app_only,
+                "combine_screens": combine_screens,
+            },
+        )
+
         # Since Local II, all images sent to local models will be rendered to text with moondream and pytesseract.
         # So we don't need to do this here— we can just emit images.
         # We should probably remove self.computer.emit_images for this reason.

--- a/src/open_interpreter/core/computer/keyboard/keyboard.py
+++ b/src/open_interpreter/core/computer/keyboard/keyboard.py
@@ -14,10 +14,19 @@ class Keyboard:
     def __init__(self, computer):
         self.computer = computer
 
+    def _summarize(self, text, limit=60):
+        if text is None:
+            return None
+        summary = str(text).strip()
+        if len(summary) > limit:
+            summary = summary[: limit - 3] + "..."
+        return summary
+
     def write(self, text, interval=None, delay=0.30, **kwargs):
         """
         Type out a string of characters with some realistic delay.
         """
+        original_text = text
         time.sleep(delay / 2)
 
         if interval:
@@ -56,6 +65,14 @@ class Keyboard:
 
         time.sleep(delay / 2)
 
+        description = f"Typing '{self._summarize(original_text)}'"
+        metadata = {"interval": interval, "delay": delay}
+        self.computer.emit_automation_event(
+            "computer.keyboard.write",
+            description,
+            metadata=metadata,
+        )
+
     def press(self, *args, presses=1, interval=0.1):
         keys = args
         """
@@ -67,6 +84,17 @@ class Keyboard:
         time.sleep(0.15)
         pyautogui.press(keys, presses=presses, interval=interval)
         time.sleep(0.15)
+        summary = (
+            ", ".join(str(k) for k in keys)
+            if isinstance(keys, (list, tuple))
+            else str(keys)
+        )
+        description = f"Pressing {self._summarize(summary)}"
+        self.computer.emit_automation_event(
+            "computer.keyboard.press",
+            description,
+            metadata={"keys": keys, "presses": presses},
+        )
 
     def press_and_release(self, *args, presses=1, interval=0.1):
         """
@@ -113,6 +141,12 @@ class Keyboard:
         else:
             pyautogui.hotkey(*args, interval=interval)
         time.sleep(0.15)
+        combo = " + ".join(str(arg) for arg in args)
+        self.computer.emit_automation_event(
+            "computer.keyboard.hotkey",
+            f"Pressing hotkey {self._summarize(combo)}",
+            metadata={"keys": list(args)},
+        )
 
     def down(self, key):
         """
@@ -121,6 +155,11 @@ class Keyboard:
         time.sleep(0.15)
         pyautogui.keyDown(key)
         time.sleep(0.15)
+        self.computer.emit_automation_event(
+            "computer.keyboard.down",
+            f"Key down {self._summarize(key)}",
+            metadata={"key": key},
+        )
 
     def up(self, key):
         """
@@ -129,3 +168,8 @@ class Keyboard:
         time.sleep(0.15)
         pyautogui.keyUp(key)
         time.sleep(0.15)
+        self.computer.emit_automation_event(
+            "computer.keyboard.up",
+            f"Key up {self._summarize(key)}",
+            metadata={"key": key},
+        )

--- a/src/open_interpreter/core/computer/mouse/mouse.py
+++ b/src/open_interpreter/core/computer/mouse/mouse.py
@@ -26,6 +26,12 @@ class Mouse:
         Scrolls the mouse wheel up or down the specified number of clicks.
         """
         pyautogui.scroll(clicks)
+        direction = "up" if clicks > 0 else "down"
+        self.computer.emit_automation_event(
+            "computer.mouse.scroll",
+            f"Scrolling {direction} {abs(clicks)} clicks",
+            metadata={"clicks": clicks},
+        )
 
     def position(self):
         """
@@ -41,10 +47,42 @@ class Mouse:
                 f"An error occurred while retrieving the mouse position: {e}. "
             )
 
+    def _summarize(self, value, limit=60):
+        if value is None:
+            return None
+        summary = str(value).strip()
+        if len(summary) > limit:
+            summary = summary[: limit - 3] + "..."
+        return summary
+
+    def _extract_target(self, args, kwargs):
+        if "text" in kwargs and kwargs["text"] is not None:
+            return "text", kwargs["text"]
+        if "icon" in kwargs and kwargs["icon"] is not None:
+            return "icon", kwargs["icon"]
+        if "x" in kwargs and "y" in kwargs:
+            return "coordinates", (kwargs["x"], kwargs["y"])
+        if len(args) == 1 and isinstance(args[0], str):
+            return "text", args[0]
+        return None, None
+
+    def _build_mouse_description(self, verb, target_type, target_value):
+        if target_type == "text":
+            return f"{verb} text '{self._summarize(target_value)}'"
+        if target_type == "icon":
+            return f"{verb} icon '{self._summarize(target_value)}'"
+        if target_type == "coordinates" and isinstance(target_value, tuple):
+            x, y = target_value
+            return f"{verb} coordinates ({int(x)}, {int(y)})"
+        return verb
+
     def move(self, *args, x=None, y=None, icon=None, text=None, screenshot=None):
         """
         Moves the mouse to specified coordinates, an icon, or text.
         """
+        target_type = None
+        target_value = None
+
         if len(args) > 1:
             raise ValueError(
                 "Too many positional arguments provided. To move/click specific coordinates, use kwargs (x=x, y=y).\n\nPlease take a screenshot with computer.display.view() to find text/icons to click, then use computer.mouse.click(text) or computer.mouse.click(icon=description_of_icon) if at all possible. This is **significantly** more accurate than using coordinates. Specifying (x=x, y=y) is highly likely to fail. Specifying ('text to click') is highly likely to succeed."
@@ -59,6 +97,9 @@ class Mouse:
             coordinates = self.computer.display.find(
                 '"' + text + '"', screenshot=screenshot
             )
+
+            target_type = "text"
+            target_value = text
 
             is_fuzzy = any([c["similarity"] != 1 for c in coordinates])
             # nah just hey, if it's fuzzy, then whatever, it prob wont see the message then decide something else (not really smart enough yet usually)
@@ -142,11 +183,16 @@ class Mouse:
                     "assistant",
                 )
             )
+            target_type = "coordinates"
+            target_value = (x, y)
         elif icon is not None:
             if screenshot == None:
                 screenshot = self.computer.display.screenshot(show=False)
 
             coordinates = self.computer.display.find(icon.strip('"'), screenshot)
+
+            target_type = "icon"
+            target_value = icon
 
             if len(coordinates) > 1:
                 if self.computer.emit_images:
@@ -227,49 +273,116 @@ class Mouse:
         # pyautogui.moveTo(x, y, duration=0.5)
         smooth_move_to(x, y)
 
+        description = self._build_mouse_description(
+            "Moving mouse to", target_type, target_value
+        )
+        metadata = {"x": x, "y": y}
+        if target_type:
+            metadata.update({"target_type": target_type, "target": target_value})
+
+        self.computer.emit_automation_event(
+            "computer.mouse.move",
+            description,
+            metadata=metadata,
+        )
+
     def click(self, *args, button="left", clicks=1, interval=0.1, **kwargs):
         """
         Clicks the mouse at the specified coordinates, icon, or text.
         """
+        target_type, target_value = self._extract_target(args, kwargs)
         if args or kwargs:
             self.move(*args, **kwargs)
         pyautogui.click(button=button, clicks=clicks, interval=interval)
+        description = self._build_mouse_description(
+            f"Clicking {button} button", target_type, target_value
+        )
+        metadata = {"button": button, "clicks": clicks}
+        if target_type:
+            metadata.update({"target_type": target_type, "target": target_value})
+        self.computer.emit_automation_event(
+            "computer.mouse.click",
+            description,
+            metadata=metadata,
+        )
 
     def double_click(self, *args, button="left", interval=0.1, **kwargs):
         """
         Double-clicks the mouse at the specified coordinates, icon, or text.
         """
+        target_type, target_value = self._extract_target(args, kwargs)
         if args or kwargs:
             self.move(*args, **kwargs)
         pyautogui.doubleClick(button=button, interval=interval)
+        description = self._build_mouse_description(
+            f"Double-clicking {button} button", target_type, target_value
+        )
+        metadata = {"button": button}
+        if target_type:
+            metadata.update({"target_type": target_type, "target": target_value})
+        self.computer.emit_automation_event(
+            "computer.mouse.double_click",
+            description,
+            metadata=metadata,
+        )
 
     def triple_click(self, *args, button="left", interval=0.1, **kwargs):
         """
         Triple-clicks the mouse at the specified coordinates, icon, or text.
         """
+        target_type, target_value = self._extract_target(args, kwargs)
         if args or kwargs:
             self.move(*args, **kwargs)
         pyautogui.tripleClick(button=button, interval=interval)
+        description = self._build_mouse_description(
+            f"Triple-clicking {button} button", target_type, target_value
+        )
+        metadata = {"button": button}
+        if target_type:
+            metadata.update({"target_type": target_type, "target": target_value})
+        self.computer.emit_automation_event(
+            "computer.mouse.triple_click",
+            description,
+            metadata=metadata,
+        )
 
     def right_click(self, *args, **kwargs):
         """
         Right-clicks the mouse at the specified coordinates, icon, or text.
         """
+        target_type, target_value = self._extract_target(args, kwargs)
         if args or kwargs:
             self.move(*args, **kwargs)
         pyautogui.rightClick()
+        description = self._build_mouse_description(
+            "Right-clicking", target_type, target_value
+        )
+        metadata = {}
+        if target_type:
+            metadata.update({"target_type": target_type, "target": target_value})
+        self.computer.emit_automation_event(
+            "computer.mouse.right_click",
+            description,
+            metadata=metadata or None,
+        )
 
     def down(self):
         """
         Presses the mouse button down.
         """
         pyautogui.mouseDown()
+        self.computer.emit_automation_event(
+            "computer.mouse.down", "Pressing mouse button down"
+        )
 
     def up(self):
         """
         Releases the mouse button.
         """
         pyautogui.mouseUp()
+        self.computer.emit_automation_event(
+            "computer.mouse.up", "Releasing mouse button"
+        )
 
 
 import math

--- a/src/open_interpreter/core/computer/os/os.py
+++ b/src/open_interpreter/core/computer/os/os.py
@@ -18,6 +18,9 @@ class Os:
         selected_text = self.computer.clipboard.view()
         # Reset the clipboard to its original content
         self.computer.clipboard.copy(current_clipboard)
+        self.computer.emit_automation_event(
+            "computer.os.get_selected_text", "Retrieving selected text"
+        )
         return selected_text
 
     def notify(self, text):

--- a/src/open_interpreter/core/runtime.py
+++ b/src/open_interpreter/core/runtime.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import threading
 import time
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Any, Deque, Dict, Optional
 
 from open_interpreter.core.conversation.defaults import default_system_message
 from open_interpreter.core.execution.truncate_output import truncate_output
@@ -14,6 +17,48 @@ from open_interpreter.core.ui import (
 )
 from open_interpreter.infrastructure.storage import OI_CONFIG_DIR, get_storage_path
 from open_interpreter.services import build_service_context
+
+
+@dataclass
+class TTSSettings:
+    """Runtime configuration for text-to-speech playback."""
+
+    enabled: bool = False
+    engine: Optional[str] = None
+    voice: Optional[str] = None
+    voice_path: Optional[str] = None
+    speaker: Optional[str] = None
+    playback_rate: float = 1.0
+    binary: Optional[str] = None
+    extra_args: Dict[str, Any] = field(default_factory=dict)
+
+    def update(self, data: Dict[str, Any]) -> None:
+        """Merge new configuration values into the settings."""
+
+        for key, value in data.items():
+            if key == "extra_args" and isinstance(value, dict):
+                self.extra_args.update(value)
+            elif hasattr(self, key):
+                setattr(self, key, value)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialise settings into a dictionary for persistence."""
+
+        payload: Dict[str, Any] = {
+            "enabled": self.enabled,
+            "engine": self.engine,
+            "voice": self.voice,
+            "voice_path": self.voice_path,
+            "speaker": self.speaker,
+            "playback_rate": self.playback_rate,
+            "binary": self.binary,
+        }
+
+        if self.extra_args:
+            payload["extra_args"] = self.extra_args
+
+        # Drop None values to keep preference files concise
+        return {k: v for k, v in payload.items() if v is not None}
 
 
 class OpenInterpreter:
@@ -135,6 +180,7 @@ class OpenInterpreter:
         # OS control mode related attributes
         self.os = os
         self.speak_messages = speak_messages
+        self.tts = TTSSettings(enabled=speak_messages)
 
         # Computer
         self.computer = self.runtime.computer
@@ -158,6 +204,9 @@ class OpenInterpreter:
         self.code_output_template = code_output_template
         self.empty_code_output_template = empty_code_output_template
         self.code_output_sender = code_output_sender
+
+        # Automation events emitted by computer actions
+        self._automation_events: Deque[Dict[str, Any]] = deque()
 
     @property
     def messages(self):
@@ -198,6 +247,39 @@ class OpenInterpreter:
     @property
     def anonymous_telemetry(self) -> bool:
         return not self.disable_telemetry and not self.offline
+
+    # ---------------------------------------------------------------------
+    # Automation event helpers
+
+    def log_automation_event(
+        self,
+        title: str,
+        description: str,
+        *,
+        action: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Record an automation event for downstream interfaces."""
+
+        payload: Dict[str, Any] = {
+            "title": title,
+            "description": description,
+            "timestamp": time.time(),
+        }
+
+        if action:
+            payload["action"] = action
+        if metadata:
+            payload["metadata"] = metadata
+
+        self._automation_events.append(payload)
+
+    def consume_automation_events(self) -> list[Dict[str, Any]]:
+        """Return and clear any queued automation events."""
+
+        events = list(self._automation_events)
+        self._automation_events.clear()
+        return events
 
     @property
     def will_contribute(self):

--- a/src/open_interpreter/interfaces/terminal/start_terminal_interface.py
+++ b/src/open_interpreter/interfaces/terminal/start_terminal_interface.py
@@ -13,6 +13,7 @@ from open_interpreter.interfaces.terminal.contributing_conversations import (
 from .conversation_navigator import conversation_navigator
 from .profiles.profiles import open_storage_dir, profile, reset_profile
 from .utils.check_for_update import check_for_update
+from .utils.preferences import load_preferences, update_preferences
 from .validate_llm_settings import validate_llm_settings
 
 
@@ -394,6 +395,12 @@ Use """ to write multi-line messages.
         )
         sys.exit(1)
 
+    preferences = load_preferences()
+    tts_preferences = preferences.get("tts") if isinstance(preferences, dict) else None
+    if tts_preferences:
+        interpreter.tts.update(tts_preferences)
+        interpreter.speak_messages = interpreter.tts.enabled
+
     if args.profiles:
         open_storage_dir("profiles")
         return
@@ -426,6 +433,7 @@ Use """ to write multi-line messages.
     ### Set attributes on interpreter, so that a profile script can read the arguments passed in via the CLI
 
     set_attributes(args, arguments)
+    interpreter.tts.enabled = interpreter.speak_messages
 
     ### Apply profile
 
@@ -473,13 +481,18 @@ Use """ to write multi-line messages.
         args.profile or get_argument_dictionary(arguments, "profile")["default"],
     )
 
+    interpreter.speak_messages = interpreter.tts.enabled
+
     ### Set attributes on interpreter, because the arguments passed in via the CLI should override profile
 
     set_attributes(args, arguments)
+    interpreter.tts.enabled = interpreter.speak_messages
     interpreter.disable_telemetry = (
         os.getenv("DISABLE_TELEMETRY", "false").lower() == "true"
         or args.disable_telemetry
     )
+
+    update_preferences("tts", interpreter.tts.to_dict())
 
     ### Set some helpful settings we know are likely to be true
 

--- a/src/open_interpreter/interfaces/terminal/terminal_interface.py
+++ b/src/open_interpreter/interfaces/terminal/terminal_interface.py
@@ -26,6 +26,20 @@ from .utils.check_for_package import check_for_package
 from .utils.cli_input import cli_input
 from .utils.display_output import display_output
 from .utils.find_image_path import find_image_path
+from .utils.notifier import Notifier
+from .utils.tts import TTSPlaybackHandle, TTSUnavailable, speak_text
+
+
+NOTIFIER = Notifier()
+
+
+def _sanitize_notification_message(message: str) -> str:
+    sanitized = message.replace("\\", "\\\\").replace("\n", " ")
+    sanitized = sanitized.replace("\r", " ")
+    sanitized = sanitized.replace('"', "'")
+    while "  " in sanitized:
+        sanitized = sanitized.replace("  ", " ")
+    return sanitized.strip()
 
 # Add examples to the readline history
 examples = [
@@ -78,7 +92,7 @@ def terminal_interface(interpreter, message):
         interactive = True
 
     active_block = None
-    voice_subprocess = None
+    voice_playback: TTSPlaybackHandle | None = None
 
     while True:
         if interactive:
@@ -300,14 +314,13 @@ def terminal_interface(interpreter, message):
                     if "content" in chunk:
                         active_block.message += chunk["content"]
 
-                    if "end" in chunk and interpreter.os:
+                    if "end" in chunk:
                         last_message = interpreter.messages[-1]["content"]
 
-                        # Remove markdown lists and the line above markdown lists
+                        # Remove markdown lists and the line above markdown lists for notifications
                         lines = last_message.split("\n")
                         i = 0
                         while i < len(lines):
-                            # Match markdown lists starting with hyphen, asterisk or number
                             if re.match(r"^\s*([-*]|\d+\.)\s", lines[i]):
                                 del lines[i]
                                 if i > 0:
@@ -315,32 +328,21 @@ def terminal_interface(interpreter, message):
                                     i -= 1
                             else:
                                 i += 1
-                        message = "\n".join(lines)
-                        # Replace newlines with spaces, escape double quotes and backslashes
-                        sanitized_message = (
-                            message.replace("\\", "\\\\")
-                            .replace("\n", " ")
-                            .replace('"', '\\"')
-                        )
+                        sanitized_message = _sanitize_notification_message("\n".join(lines))
 
-                        # Display notification in OS mode
-                        interpreter.computer.os.notify(sanitized_message)
+                        if interpreter.os:
+                            NOTIFIER.notify(sanitized_message)
 
-                        # Speak message aloud
-                        if platform.system() == "Darwin" and interpreter.speak_messages:
-                            if voice_subprocess:
-                                voice_subprocess.terminate()
-                            voice_subprocess = subprocess.Popen(
-                                [
-                                    "osascript",
-                                    "-e",
-                                    f'say "{sanitized_message}" using "Fred"',
-                                ]
-                            )
-                        else:
-                            pass
-                            # User isn't on a Mac, so we can't do this. You should tell them something about that when they first set this up.
-                            # Or use a universal TTS library.
+                        if interpreter.tts.enabled:
+                            if voice_playback:
+                                voice_playback.stop()
+                                voice_playback = None
+                            try:
+                                voice_playback = speak_text(sanitized_message, interpreter.tts)
+                            except TTSUnavailable as exc:
+                                if interpreter.verbose:
+                                    print(f"TTS unavailable: {exc}")
+                                interpreter.tts.enabled = False
 
                 # Assistant code blocks
                 elif chunk["role"] == "assistant" and chunk["type"] == "code":
@@ -438,71 +440,6 @@ def terminal_interface(interpreter, message):
                     if "format" in chunk and chunk["format"] == "active_line":
                         active_block.active_line = chunk["content"]
 
-                        # Display action notifications if we're in OS mode
-                        if interpreter.os and active_block.active_line != None:
-                            action = ""
-
-                            code_lines = active_block.code.split("\n")
-                            if active_block.active_line < len(code_lines):
-                                action = code_lines[active_block.active_line].strip()
-
-                            if action.startswith("computer"):
-                                description = None
-
-                                # Extract arguments from the action
-                                start_index = action.find("(")
-                                end_index = action.rfind(")")
-                                if start_index != -1 and end_index != -1:
-                                    # (If we found both)
-                                    arguments = action[start_index + 1 : end_index]
-                                else:
-                                    arguments = None
-
-                                # NOTE: Do not put the text you're clicking on screen
-                                # (unless we figure out how to do this AFTER taking the screenshot)
-                                # otherwise it will try to click this notification!
-
-                                if any(
-                                    action.startswith(text)
-                                    for text in [
-                                        "computer.screenshot",
-                                        "computer.display.screenshot",
-                                        "computer.display.view",
-                                        "computer.view",
-                                    ]
-                                ):
-                                    description = "Viewing screen..."
-                                elif action == "computer.mouse.click()":
-                                    description = "Clicking..."
-                                elif action.startswith("computer.mouse.click("):
-                                    if "icon=" in arguments:
-                                        text_or_icon = "icon"
-                                    else:
-                                        text_or_icon = "text"
-                                    description = f"Clicking {text_or_icon}..."
-                                elif action.startswith("computer.mouse.move("):
-                                    if "icon=" in arguments:
-                                        text_or_icon = "icon"
-                                    else:
-                                        text_or_icon = "text"
-                                    if (
-                                        "click" in active_block.code
-                                    ):  # This could be better
-                                        description = f"Clicking {text_or_icon}..."
-                                    else:
-                                        description = f"Mousing over {text_or_icon}..."
-                                elif action.startswith("computer.keyboard.write("):
-                                    description = f"Typing {arguments}."
-                                elif action.startswith("computer.keyboard.hotkey("):
-                                    description = f"Pressing {arguments}."
-                                elif action.startswith("computer.keyboard.press("):
-                                    description = f"Pressing {arguments}."
-                                elif action == "computer.os.get_selected_text()":
-                                    description = f"Getting selected text."
-
-                                if description:
-                                    interpreter.computer.os.notify(description)
-
                     if "start" in chunk:
                         # We need to make a code block if we pushed out an HTML block first, which would have closed our code block.
                         if not isinstance(active_block, CodeBlock):
@@ -512,6 +449,14 @@ def terminal_interface(interpreter, message):
 
                 if active_block:
                     active_block.refresh(cursor=render_cursor)
+
+                events = interpreter.consume_automation_events()
+                if events:
+                    for event in events:
+                        title = event.get("title")
+                        description = event.get("description", "")
+                        if interpreter.os:
+                            NOTIFIER.notify(description, title=title)
 
             # (Sometimes -- like if they CTRL-C quickly -- active_block is still None here)
             if "active_block" in locals():

--- a/src/open_interpreter/interfaces/terminal/utils/notifier.py
+++ b/src/open_interpreter/interfaces/terminal/utils/notifier.py
@@ -1,0 +1,136 @@
+"""Cross-platform notification helper for the terminal interface."""
+
+from __future__ import annotations
+
+import platform
+import shutil
+import subprocess
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class NotificationResult:
+    """Details about a delivered notification."""
+
+    success: bool
+    channel: str | None = None
+
+
+class Notifier:
+    """Dispatch small desktop notifications where possible."""
+
+    def __init__(self, default_title: str = "Open Interpreter") -> None:
+        self.default_title = default_title
+
+    # ------------------------------------------------------------------
+    # Public API
+
+    def notify(self, message: str, title: Optional[str] = None) -> NotificationResult:
+        """Attempt to show an OS level notification."""
+
+        if not message:
+            return NotificationResult(False)
+
+        heading = self._sanitize(title or self.default_title)
+        body = self._sanitize(message)
+        system = platform.system().lower()
+
+        if "darwin" in system:
+            return NotificationResult(self._notify_macos(heading, body), "macos")
+        if "windows" in system:
+            return NotificationResult(self._notify_windows(heading, body), "windows")
+        return NotificationResult(self._notify_unix(heading, body), "unix")
+
+    # ------------------------------------------------------------------
+    # Platform handlers
+
+    def _notify_macos(self, title: str, message: str) -> bool:
+        script = f'display notification "{message}" with title "{title}"'
+        try:
+            subprocess.run(["osascript", "-e", script], check=False)
+            return True
+        except Exception:
+            return False
+
+    def _notify_windows(self, title: str, message: str) -> bool:
+        # Try Toastify/Win10 toast notifications first
+        for module_name, attribute in (("toastify", "Toast"), ("win10toast", "ToastNotifier")):
+            try:
+                module = __import__(module_name, fromlist=[attribute])
+                notifier_cls = getattr(module, attribute)
+                notifier = notifier_cls()
+                if module_name == "toastify":
+                    notifier.show_toast(title=title, msg=message, duration=5)
+                else:
+                    notifier.show_toast(title, message, duration=5, threaded=True)
+                return True
+            except Exception:
+                continue
+
+        # Fallback to plyer if available
+        try:
+            from plyer import notification
+
+            notification.notify(title=title, message=message)
+            return True
+        except Exception:
+            pass
+
+        # As a last resort, try PowerShell via System.Windows.Forms
+        powershell = shutil.which("powershell") or shutil.which("pwsh")
+        if not powershell:
+            return False
+
+        script = (
+            "Add-Type -AssemblyName System.Windows.Forms;"
+            "Add-Type -AssemblyName System.Drawing;"
+            "$notify = New-Object System.Windows.Forms.NotifyIcon;"
+            "$notify.Icon = [System.Drawing.SystemIcons]::Information;"
+            f"$notify.BalloonTipTitle = '{title}';"
+            f"$notify.BalloonTipText = '{message}';"
+            "$notify.Visible = $true;"
+            "$notify.ShowBalloonTip(3000);"
+            "Start-Sleep -Seconds 5;"
+            "$notify.Dispose();"
+        )
+
+        try:
+            subprocess.Popen([powershell, "-NoLogo", "-NoProfile", "-Command", script])
+            return True
+        except Exception:
+            return False
+
+    def _notify_unix(self, title: str, message: str) -> bool:
+        # Prefer plyer on Linux/Unix
+        try:
+            from plyer import notification
+
+            notification.notify(title=title, message=message)
+            return True
+        except Exception:
+            pass
+
+        notify_send = shutil.which("notify-send")
+        if notify_send:
+            try:
+                subprocess.run([notify_send, title, message], check=False)
+                return True
+            except Exception:
+                pass
+
+        return False
+
+    # ------------------------------------------------------------------
+    # Helpers
+
+    def _sanitize(self, value: str) -> str:
+        value = value.replace("\n", " ").strip()
+        value = value.replace("\"", "'")
+        value = value.replace("'", "’")
+        if len(value) > 200:
+            value = value[:197] + "..."
+        return value
+
+
+__all__ = ["Notifier", "NotificationResult"]

--- a/src/open_interpreter/interfaces/terminal/utils/preferences.py
+++ b/src/open_interpreter/interfaces/terminal/utils/preferences.py
@@ -1,0 +1,55 @@
+"""Lightweight helpers for persisting terminal interface preferences."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Dict, Optional
+
+from .local_storage_path import get_storage_path
+
+PREFERENCES_FILENAME = "preferences.json"
+
+
+def _preferences_path() -> str:
+    return os.path.join(get_storage_path(), PREFERENCES_FILENAME)
+
+
+def load_preferences() -> Dict[str, Any]:
+    """Load persisted preferences from disk."""
+
+    path = _preferences_path()
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            data = json.load(handle)
+            if isinstance(data, dict):
+                return data
+    except FileNotFoundError:
+        return {}
+    except json.JSONDecodeError:
+        return {}
+    return {}
+
+
+def save_preferences(data: Dict[str, Any]) -> None:
+    """Persist the entire preferences mapping to disk."""
+
+    path = _preferences_path()
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump(data, handle, indent=2, sort_keys=True)
+
+
+def update_preferences(section: str, values: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Merge a section into the stored preferences file."""
+
+    preferences = load_preferences()
+    if values is None:
+        preferences.pop(section, None)
+    else:
+        preferences[section] = values
+    save_preferences(preferences)
+    return preferences
+
+
+__all__ = ["load_preferences", "save_preferences", "update_preferences", "PREFERENCES_FILENAME"]

--- a/src/open_interpreter/interfaces/terminal/utils/tts.py
+++ b/src/open_interpreter/interfaces/terminal/utils/tts.py
@@ -1,0 +1,164 @@
+"""Utilities for speaking assistant responses via local TTS engines."""
+
+from __future__ import annotations
+
+import os
+import platform
+import shutil
+import subprocess
+import tempfile
+import threading
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - used for type hints only
+    from open_interpreter.core.runtime import TTSSettings
+
+
+class TTSUnavailable(RuntimeError):
+    """Raised when a requested TTS engine cannot be used."""
+
+
+@dataclass
+class TTSPlaybackHandle:
+    process: Optional[subprocess.Popen] = None
+    file_path: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if self.process and self.file_path:
+            thread = threading.Thread(target=self._cleanup, daemon=True)
+            thread.start()
+
+    def stop(self) -> None:
+        if self.process and self.process.poll() is None:
+            self.process.terminate()
+        self._remove_file()
+
+    def _cleanup(self) -> None:
+        if self.process:
+            try:
+                self.process.wait()
+            except Exception:
+                pass
+        self._remove_file()
+
+    def _remove_file(self) -> None:
+        if self.file_path and os.path.exists(self.file_path):
+            try:
+                os.remove(self.file_path)
+            except OSError:
+                pass
+
+
+_COQUI_MODELS: Dict[str, Any] = {}
+
+
+def speak_text(text: str, settings: "TTSSettings") -> Optional[TTSPlaybackHandle]:
+    """Generate speech for ``text`` using the configured engine."""
+
+    if not text or not getattr(settings, "enabled", False):
+        return None
+
+    engine = (getattr(settings, "engine", None) or "coqui").lower()
+
+    if engine == "piper":
+        audio_path = _synthesise_with_piper(text, settings)
+    else:
+        audio_path = _synthesise_with_coqui(text, settings)
+
+    return _play_audio(audio_path)
+
+
+def _synthesise_with_coqui(text: str, settings: "TTSSettings") -> str:
+    try:
+        from TTS.api import TTS as CoquiTTS
+    except ImportError as exc:  # pragma: no cover - optional dependency
+        raise TTSUnavailable(
+            "Coqui TTS engine requires the `TTS` package. Install it with `pip install TTS`."
+        ) from exc
+
+    voice_id = getattr(settings, "voice", None) or "tts_models/en/vctk/vits"
+    key = voice_id
+
+    if key not in _COQUI_MODELS:
+        kwargs: Dict[str, Any] = {"model_name": voice_id}
+        if getattr(settings, "voice_path", None):
+            kwargs = {"model_path": settings.voice_path}
+        _COQUI_MODELS[key] = CoquiTTS(**kwargs)
+
+    output = tempfile.NamedTemporaryFile(suffix=".wav", delete=False)
+    output.close()
+
+    speaker = getattr(settings, "speaker", None)
+
+    _COQUI_MODELS[key].tts_to_file(
+        text=text,
+        file_path=output.name,
+        speaker=speaker,
+    )
+    return output.name
+
+
+def _synthesise_with_piper(text: str, settings: "TTSSettings") -> str:
+    voice_path = getattr(settings, "voice_path", None) or getattr(settings, "voice", None)
+    if not voice_path:
+        raise TTSUnavailable("Piper requires `voice` or `voice_path` pointing to a model file.")
+
+    binary = getattr(settings, "binary", None) or "piper"
+    if not shutil.which(binary):
+        raise TTSUnavailable(f"Unable to locate Piper binary '{binary}'.")
+
+    output = tempfile.NamedTemporaryFile(suffix=".wav", delete=False)
+    output.close()
+
+    command = [binary, "--model", voice_path, "--output_file", output.name]
+
+    speaker = getattr(settings, "speaker", None)
+    if speaker is not None:
+        command.extend(["--speaker", str(speaker)])
+
+    extra_args = getattr(settings, "extra_args", {}) or {}
+    for key, value in extra_args.items():
+        command.append(str(key))
+        if value is not None:
+            command.append(str(value))
+
+    try:
+        subprocess.run(command, input=text.encode("utf-8"), check=True)
+    except subprocess.CalledProcessError as exc:
+        raise TTSUnavailable("Piper synthesis failed. Check your voice model path.") from exc
+
+    return output.name
+
+
+def _play_audio(file_path: str) -> TTSPlaybackHandle:
+    system = platform.system().lower()
+
+    if "darwin" in system:
+        player = ["afplay", file_path]
+    elif "windows" in system:
+        powershell = shutil.which("powershell") or shutil.which("pwsh")
+        if not powershell:
+            raise TTSUnavailable("PowerShell is required for audio playback on Windows.")
+        script = f"(New-Object Media.SoundPlayer '{file_path}').PlaySync()"
+        player = [powershell, "-NoLogo", "-NoProfile", "-Command", script]
+    else:
+        player = None
+        for candidate in (["paplay", file_path], ["aplay", file_path], ["ffplay", "-nodisp", "-autoexit", file_path]):
+            if shutil.which(candidate[0]):
+                player = candidate
+                break
+        if player is None:
+            raise TTSUnavailable(
+                "No audio playback utility found. Install `paplay`, `aplay`, or `ffplay` to enable TTS playback."
+            )
+
+    try:
+        process = subprocess.Popen(player)
+    except FileNotFoundError as exc:
+        raise TTSUnavailable("Failed to start audio playback process.") from exc
+
+    return TTSPlaybackHandle(process=process, file_path=file_path)
+
+
+__all__ = ["speak_text", "TTSPlaybackHandle", "TTSUnavailable"]


### PR DESCRIPTION
## Summary
- add a shared notifier utility and integrate it with the terminal interface to deliver OS notifications and spoken responses
- emit structured automation events from computer peripherals so the terminal interface can surface concise activity updates
- introduce configurable TTS voice settings with preference persistence and support for open-source engines such as Coqui and Piper

## Testing
- python -m compileall src/open_interpreter/core/runtime.py src/open_interpreter/core/computer/computer.py src/open_interpreter/core/computer/mouse/mouse.py src/open_interpreter/core/computer/keyboard/keyboard.py src/open_interpreter/core/computer/display/display.py src/open_interpreter/core/computer/os/os.py src/open_interpreter/interfaces/terminal/terminal_interface.py src/open_interpreter/interfaces/terminal/start_terminal_interface.py src/open_interpreter/interfaces/terminal/utils/notifier.py src/open_interpreter/interfaces/terminal/utils/preferences.py src/open_interpreter/interfaces/terminal/utils/tts.py

------
https://chatgpt.com/codex/tasks/task_e_68d638913b84832e982ead54d4008816