### PR TITLE
Add terminal artifact previews and quick actions

### DIFF
--- a/src/open_interpreter/interfaces/terminal/terminal_interface.py
+++ b/src/open_interpreter/interfaces/terminal/terminal_interface.py
@@ -12,6 +12,7 @@ import os
 import platform
 import random
 import re
+import shlex
 import subprocess
 import tempfile
 import time
@@ -24,8 +25,84 @@ from .components.message_block import MessageBlock
 from .magic_commands import handle_magic_command
 from .utils.check_for_package import check_for_package
 from .utils.cli_input import cli_input
-from .utils.display_output import display_output
+from .utils.artifact_manager import ArtifactManager
+from .utils.display_output import display_output, open_file
 from .utils.find_image_path import find_image_path
+
+
+def handle_artifact_quick_action(command: str, artifact_manager: ArtifactManager) -> bool:
+    try:
+        parts = shlex.split(command[1:])
+    except ValueError as exc:
+        print(f"Artifact command error: {exc}")
+        return True
+
+    if not parts:
+        return False
+
+    action = parts[0].lower()
+
+    if action in {"open", "o"}:
+        if len(parts) < 2:
+            print("Usage: :open <artifact_id>")
+            return True
+        artifact_id = _parse_artifact_id(parts[1])
+        if artifact_id is None:
+            return True
+        artifact = artifact_manager.get(artifact_id)
+        if not artifact:
+            print(f"No artifact found with id {artifact_id}.")
+            return True
+        try:
+            path = artifact.ensure_cached_path()
+        except Exception as exc:
+            print(f"Unable to load artifact {artifact_id}: {exc}")
+            return True
+        open_file(path)
+        print(f"Opened artifact {artifact_id} at {path}.")
+        return True
+
+    if action in {"save", "s"}:
+        if len(parts) < 3:
+            print("Usage: :save <artifact_id> <destination>")
+            return True
+        artifact_id = _parse_artifact_id(parts[1])
+        if artifact_id is None:
+            return True
+        destination = " ".join(parts[2:])
+        try:
+            saved_path = artifact_manager.save(artifact_id, destination)
+        except OSError as exc:
+            print(f"Failed to save artifact {artifact_id}: {exc}")
+            return True
+        if not saved_path:
+            print(f"No artifact found with id {artifact_id}.")
+        else:
+            print(f"Saved artifact {artifact_id} to {saved_path}.")
+        return True
+
+    if action in {"discard", "d"}:
+        if len(parts) < 2:
+            print("Usage: :discard <artifact_id>")
+            return True
+        artifact_id = _parse_artifact_id(parts[1])
+        if artifact_id is None:
+            return True
+        if artifact_manager.discard(artifact_id):
+            print(f"Discarded artifact {artifact_id}.")
+        else:
+            print(f"No artifact found with id {artifact_id}.")
+        return True
+
+    return False
+
+
+def _parse_artifact_id(raw_id: str):
+    try:
+        return int(raw_id)
+    except ValueError:
+        print(f"Invalid artifact id: {raw_id}")
+        return None
 
 # Add examples to the readline history
 examples = [
@@ -79,84 +156,89 @@ def terminal_interface(interpreter, message):
 
     active_block = None
     voice_subprocess = None
+    artifact_manager = ArtifactManager()
 
     while True:
         if interactive:
-            if (
-                len(interpreter.messages) == 1
-                and interpreter.messages[-1]["role"] == "user"
-                and interpreter.messages[-1]["type"] == "message"
-            ):
-                # They passed in a message already, probably via "i {command}"!
-                message = interpreter.messages[-1]["content"]
-                interpreter.messages = interpreter.messages[:-1]
-            else:
-                ### This is the primary input for Open Interpreter.
-                try:
-                    message = (
-                        cli_input("> ").strip()
-                        if interpreter.multi_line
-                        else input("> ").strip()
-                    )
-                except (KeyboardInterrupt, EOFError):
-                    # Treat Ctrl-D on an empty line the same as Ctrl-C by exiting gracefully
-                    interpreter.display_message("\n\n`Exiting...`")
-                    raise KeyboardInterrupt
+                if (
+                    len(interpreter.messages) == 1
+                    and interpreter.messages[-1]["role"] == "user"
+                    and interpreter.messages[-1]["type"] == "message"
+                ):
+                    # They passed in a message already, probably via "i {command}"!
+                    message = interpreter.messages[-1]["content"]
+                    interpreter.messages = interpreter.messages[:-1]
+                else:
+                    ### This is the primary input for Open Interpreter.
+                    try:
+                        message = (
+                            cli_input("> ").strip()
+                            if interpreter.multi_line
+                            else input("> ").strip()
+                        )
+                    except (KeyboardInterrupt, EOFError):
+                        # Treat Ctrl-D on an empty line the same as Ctrl-C by exiting gracefully
+                        interpreter.display_message("\n\n`Exiting...`")
+                        raise KeyboardInterrupt
 
-            try:
-                # This lets users hit the up arrow key for past messages
-                readline.add_history(message)
-            except:
-                # If the user doesn't have readline (may be the case on windows), that's fine
-                pass
+                try:
+                    # This lets users hit the up arrow key for past messages
+                    readline.add_history(message)
+                except:
+                    # If the user doesn't have readline (may be the case on windows), that's fine
+                    pass
 
         if isinstance(message, str):
-            # This is for the terminal interface being used as a CLI — messages are strings.
-            # This won't fire if they're in the python package, display=True, and they passed in an array of messages (for example).
+                # This is for the terminal interface being used as a CLI — messages are strings.
+                # This won't fire if they're in the python package, display=True, and they passed in an array of messages (for example).
 
-            if message == "":
-                # Ignore empty messages when user presses enter without typing anything
-                continue
+                if message == "":
+                    # Ignore empty messages when user presses enter without typing anything
+                    continue
 
-            if message.startswith("%") and interactive:
-                handle_magic_command(interpreter, message)
-                continue
+                if message.startswith(":") and interactive:
+                    if handle_artifact_quick_action(message, artifact_manager):
+                        continue
 
-            # Many users do this
-            if message.strip() == "interpreter --local":
-                print("Please exit this conversation, then run `interpreter --local`.")
-                continue
-            if message.strip() == "pip install --upgrade open-interpreter":
-                print(
-                    "Please exit this conversation, then run `pip install --upgrade open-interpreter`."
-                )
-                continue
+                if message.startswith("%") and interactive:
+                    handle_magic_command(interpreter, message)
+                    continue
 
-            if (
-                interpreter.llm.supports_vision
-                or interpreter.llm.vision_renderer != None
-            ):
-                # Is the input a path to an image? Like they just dragged it into the terminal?
-                image_path = find_image_path(message)
-
-                ## If we found an image, add it to the message
-                if image_path:
-                    # Add the text interpreter's message history
-                    interpreter.messages.append(
-                        {
-                            "role": "user",
-                            "type": "message",
-                            "content": message,
-                        }
+                # Many users do this
+                if message.strip() == "interpreter --local":
+                    print("Please exit this conversation, then run `interpreter --local`.")
+                    continue
+                if message.strip() == "pip install --upgrade open-interpreter":
+                    print(
+                        "Please exit this conversation, then run `pip install --upgrade open-interpreter`."
                     )
+                    continue
 
-                    # Pass in the image to interpreter in a moment
-                    message = {
-                        "role": "user",
-                        "type": "image",
-                        "format": "path",
-                        "content": image_path,
-                    }
+                if (
+                    interpreter.llm.supports_vision
+                    or interpreter.llm.vision_renderer != None
+                ):
+                    # Is the input a path to an image? Like they just dragged it into the terminal?
+                    image_path = find_image_path(message)
+
+                    ## If we found an image, add it to the message
+                    if image_path:
+                        # Add the text interpreter's message history
+                        interpreter.messages.append(
+                            {
+                                "role": "user",
+                                "type": "message",
+                                "content": message,
+                            }
+                        )
+
+                        # Pass in the image to interpreter in a moment
+                        message = {
+                            "role": "user",
+                            "type": "image",
+                            "format": "path",
+                            "content": image_path,
+                        }
 
         try:
             for chunk in interpreter.chat(message, display=False, stream=True):
@@ -389,7 +471,9 @@ def terminal_interface(interpreter, message):
                             continue
 
                     # Display and give extra output back to the LLM
-                    extra_computer_output = display_output(chunk)
+                    extra_computer_output = display_output(
+                        chunk, artifact_manager=artifact_manager
+                    )
 
                     # We're going to just add it to the messages directly, not changing `recipient` here.
                     # Mind you, the way we're doing this, this would make it appear to the user if they look at their conversation history,
@@ -522,7 +606,8 @@ def terminal_interface(interpreter, message):
 
             if not interactive:
                 # Don't loop
-                break
+                artifact_manager.cleanup()
+                return
 
         except KeyboardInterrupt:
             # Exit gracefully
@@ -534,8 +619,10 @@ def terminal_interface(interpreter, message):
                 # (this cancels LLM, returns to the interactive "> " input)
                 continue
             else:
-                break
+                artifact_manager.cleanup()
+                return
         except:
             if interpreter.debug:
                 system_info(interpreter)
+            artifact_manager.cleanup()
             raise

--- a/src/open_interpreter/interfaces/terminal/utils/artifact_manager.py
+++ b/src/open_interpreter/interfaces/terminal/utils/artifact_manager.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import atexit
+import os
+import shutil
+from dataclasses import dataclass, field
+from typing import Callable, Dict, Optional
+
+
+EnsurePathCallable = Callable[[], str]
+
+
+@dataclass
+class Artifact:
+    """Metadata for a generated artifact."""
+
+    id: int
+    kind: str
+    description: str
+    ensure_path: EnsurePathCallable
+    is_temporary: bool = True
+    size_bytes: Optional[int] = None
+    preview_label: Optional[str] = None
+    _cached_path: Optional[str] = field(default=None, init=False, repr=False)
+
+    def ensure_cached_path(self) -> str:
+        """Return a local path to the artifact, materialising it if necessary."""
+
+        if self._cached_path and os.path.exists(self._cached_path):
+            return self._cached_path
+
+        path = self.ensure_path()
+        self._cached_path = path
+        return path
+
+    def cleanup(self) -> None:
+        """Remove any temporary files owned by this artifact."""
+
+        if not self.is_temporary:
+            return
+
+        path = self._cached_path
+        if path and os.path.exists(path):
+            try:
+                os.remove(path)
+            except OSError:
+                pass
+
+
+class ArtifactManager:
+    """Tracks artifacts created during a terminal session."""
+
+    def __init__(self) -> None:
+        self._artifacts: Dict[int, Artifact] = {}
+        self._counter: int = 1
+        atexit.register(self.cleanup)
+
+    def register(
+        self,
+        kind: str,
+        description: str,
+        ensure_path: EnsurePathCallable,
+        *,
+        is_temporary: bool = True,
+        size_bytes: Optional[int] = None,
+        preview_label: Optional[str] = None,
+    ) -> Artifact:
+        """Register a new artifact and return its metadata."""
+
+        artifact_id = self._counter
+        self._counter += 1
+
+        artifact = Artifact(
+            id=artifact_id,
+            kind=kind,
+            description=description,
+            ensure_path=ensure_path,
+            is_temporary=is_temporary,
+            size_bytes=size_bytes,
+            preview_label=preview_label,
+        )
+
+        self._artifacts[artifact_id] = artifact
+        return artifact
+
+    def get(self, artifact_id: int) -> Optional[Artifact]:
+        return self._artifacts.get(artifact_id)
+
+    def discard(self, artifact_id: int) -> bool:
+        artifact = self._artifacts.pop(artifact_id, None)
+        if not artifact:
+            return False
+
+        artifact.cleanup()
+        return True
+
+    def cleanup(self) -> None:
+        for artifact_id in list(self._artifacts.keys()):
+            self.discard(artifact_id)
+
+    def save(self, artifact_id: int, destination: str) -> Optional[str]:
+        artifact = self.get(artifact_id)
+        if not artifact:
+            return None
+
+        source_path = artifact.ensure_cached_path()
+        destination = os.path.expanduser(destination)
+        destination = os.path.abspath(destination)
+
+        if os.path.isdir(destination):
+            basename = os.path.basename(source_path)
+            destination = os.path.join(destination, basename)
+
+        os.makedirs(os.path.dirname(destination), exist_ok=True)
+        shutil.copy2(source_path, destination)
+        return destination

--- a/src/open_interpreter/interfaces/terminal/utils/display_output.py
+++ b/src/open_interpreter/interfaces/terminal/utils/display_output.py
@@ -1,13 +1,37 @@
 import base64
 import os
 import platform
+import shutil
 import subprocess
 import tempfile
+from typing import Optional, Tuple
 
 from .in_jupyter_notebook import in_jupyter_notebook
+from .artifact_manager import Artifact, ArtifactManager
+
+try:
+    from rich.console import Console
+    from rich.image import Image as RichImage
+    from rich.panel import Panel
+    from rich.syntax import Syntax
+except Exception:  # pragma: no cover - rich is an optional dependency in some envs
+    Console = None
+    RichImage = None
+    Panel = None
+    Syntax = None
 
 
-def display_output(output):
+CONSOLE = Console() if Console else None
+
+
+ARTIFACT_ICONS = {
+    "image": "🖼️",
+    "html": "🌐",
+    "javascript": "🧩",
+}
+
+
+def display_output(output, artifact_manager: Optional[ArtifactManager] = None):
     if in_jupyter_notebook():
         from IPython.display import HTML, Image, Javascript, display
 
@@ -26,50 +50,310 @@ def display_output(output):
         elif "format" in output and output["format"] == "javascript":
             display(Javascript(output["content"]))
     else:
-        display_output_cli(output)
+        return display_output_cli(output, artifact_manager=artifact_manager)
 
     # Return a message for the LLM.
-    # We should make this specific to what happened in the future,
-    # like saying WHAT temporary file we made, etc. Keep the LLM informed.
     return "Displayed on the user's machine."
 
 
-def display_output_cli(output):
-    if output["type"] == "console":
+def display_output_cli(
+    output, artifact_manager: Optional[ArtifactManager] = None
+) -> str:
+    output_type = output.get("type")
+    format_hint = output.get("format")
+
+    if output_type == "console":
         print(output["content"])
-    elif output["type"] == "image":
-        if "base64" in output["format"]:
-            if "." in output["format"]:
-                extension = output["format"].split(".")[-1]
+        return output["content"]
+
+    if output_type == "image":
+        return _handle_image_output(output, artifact_manager)
+
+    if format_hint == "html":
+        return _handle_textual_artifact(
+            output,
+            artifact_manager,
+            kind="html",
+            extension=".html",
+            language="html",
+        )
+
+    if format_hint == "javascript":
+        return _handle_textual_artifact(
+            output,
+            artifact_manager,
+            kind="javascript",
+            extension=".js",
+            language="javascript",
+        )
+
+    if format_hint == "path":
+        return _handle_path_artifact(output, artifact_manager)
+
+    return "Displayed on the user's machine."
+
+
+def _handle_path_artifact(output, artifact_manager: Optional[ArtifactManager]) -> str:
+    path = output.get("content")
+    if not path:
+        return "Received artifact with no path."
+
+    description = os.path.basename(path) or "artifact"
+    size = None
+    try:
+        size = os.path.getsize(path)
+    except OSError:
+        pass
+
+    preview_label = _render_image_preview(path=path)
+
+    if artifact_manager:
+        artifact = artifact_manager.register(
+            kind=output.get("type", "artifact"),
+            description=description,
+            ensure_path=lambda: path,
+            is_temporary=False,
+            size_bytes=size,
+            preview_label=_describe_preview(preview_label),
+        )
+        return _format_artifact_transcript(artifact)
+
+    open_file(path)
+    return f"Opened artifact at {path}."
+
+
+def _handle_image_output(output, artifact_manager: Optional[ArtifactManager]) -> str:
+    format_hint = output.get("format", "")
+    extension = "png"
+    if "." in format_hint:
+        extension = format_hint.split(".")[-1]
+
+    temp_path: Optional[str] = None
+    image_bytes: Optional[bytes] = None
+    is_temporary = True
+
+    if "base64" in format_hint:
+        raw_content = output.get("content", "")
+        if isinstance(raw_content, bytes):
+            raw_content = raw_content.decode()
+        try:
+            image_bytes = base64.b64decode(raw_content)
+        except Exception:
+            image_bytes = b""
+
+        def ensure_path() -> str:
+            nonlocal temp_path
+            if temp_path and os.path.exists(temp_path):
+                return temp_path
+            with tempfile.NamedTemporaryFile(delete=False, suffix=f".{extension}") as tmp_file:
+                tmp_file.write(image_bytes)
+                temp_path = tmp_file.name
+            return temp_path
+
+    elif format_hint == "path":
+        path = output.get("content")
+
+        def ensure_path(path=path) -> str:
+            return path
+
+        is_temporary = False
+        temp_path = path
+    else:
+        raw_content = output.get("content", b"")
+        if isinstance(raw_content, bytes):
+            image_bytes = bytes(raw_content)
+        elif isinstance(raw_content, bytearray):
+            image_bytes = bytes(raw_content)
+        else:
+            image_bytes = str(raw_content).encode("utf-8")
+
+        def ensure_path() -> str:
+            nonlocal temp_path
+            if temp_path and os.path.exists(temp_path):
+                return temp_path
+            with tempfile.NamedTemporaryFile(delete=False, suffix=f".{extension}") as tmp_file:
+                tmp_file.write(image_bytes)
+                temp_path = tmp_file.name
+            return temp_path
+
+    preview_source = None
+    if image_bytes is not None:
+        preview_source = _render_image_preview(image_bytes=image_bytes)
+    else:
+        preview_source = _render_image_preview(path=temp_path or ensure_path())
+
+    if not preview_source:
+        preview_source = _render_sixel_preview(ensure_path())
+
+    size = None
+    if image_bytes is not None:
+        size = len(image_bytes)
+    else:
+        try:
+            size = os.path.getsize(ensure_path())
+        except OSError:
+            pass
+
+    if artifact_manager:
+        artifact = artifact_manager.register(
+            kind="image",
+            description=f"{extension.upper()} image",
+            ensure_path=ensure_path,
+            is_temporary=is_temporary,
+            size_bytes=size,
+            preview_label=_describe_preview(preview_source),
+        )
+        return _format_artifact_transcript(artifact)
+
+    path = ensure_path()
+    open_file(path)
+    return f"Opened image at {path}."
+
+
+def _handle_textual_artifact(
+    output,
+    artifact_manager: Optional[ArtifactManager],
+    *,
+    kind: str,
+    extension: str,
+    language: str,
+) -> str:
+    content = output.get("content", "")
+    if not isinstance(content, str):
+        content = str(content)
+    text = content or ""
+    truncated, was_truncated = _truncate_text(text)
+    preview_source = _render_text_preview(truncated, language)
+
+    def ensure_path() -> str:
+        with tempfile.NamedTemporaryFile(delete=False, suffix=extension, mode="w") as tmp_file:
+            tmp_file.write(content)
+            return tmp_file.name
+
+    preview_label = _describe_preview(preview_source, was_truncated)
+    size = len(content.encode("utf-8")) if isinstance(content, str) else None
+
+    if artifact_manager:
+        artifact = artifact_manager.register(
+            kind=kind,
+            description=f"{kind.upper()} artifact",
+            ensure_path=ensure_path,
+            is_temporary=True,
+            size_bytes=size,
+            preview_label=preview_label,
+        )
+        return _format_artifact_transcript(artifact)
+
+    path = ensure_path()
+    open_file(path)
+    return f"Opened {kind} artifact at {path}."
+
+
+def _render_image_preview(
+    image_bytes: Optional[bytes] = None, *, path: Optional[str] = None
+) -> Optional[str]:
+    if CONSOLE and RichImage:
+        try:
+            if image_bytes is not None:
+                image = RichImage.from_buffer(image_bytes)
+            elif path:
+                image = RichImage.from_path(path)
             else:
-                extension = "png"
-            with tempfile.NamedTemporaryFile(
-                delete=False, suffix="." + extension
-            ) as tmp_file:
-                image_data = base64.b64decode(output["content"])
-                tmp_file.write(image_data)
+                return None
+            CONSOLE.print(image)
+            return "rich"
+        except Exception:
+            pass
+    return None
 
-                # # Display in Terminal (DISABLED, i couldn't get it to work)
-                # from term_image.image import from_file
-                # image = from_file(tmp_file.name)
-                # image.draw()
 
-                open_file(tmp_file.name)
-        elif output["format"] == "path":
-            open_file(output["content"])
-    elif "format" in output and output["format"] == "html":
-        with tempfile.NamedTemporaryFile(
-            delete=False, suffix=".html", mode="w"
-        ) as tmp_file:
-            html = output["content"]
-            tmp_file.write(html)
-            open_file(tmp_file.name)
-    elif "format" in output and output["format"] == "javascript":
-        with tempfile.NamedTemporaryFile(
-            delete=False, suffix=".js", mode="w"
-        ) as tmp_file:
-            tmp_file.write(output["content"])
-            open_file(tmp_file.name)
+def _render_sixel_preview(path: str) -> Optional[str]:
+    if not path:
+        return None
+    sixel_cmd = shutil.which("img2sixel")
+    if not sixel_cmd:
+        return None
+    try:
+        subprocess.run([sixel_cmd, path], check=True)
+        return "sixel"
+    except Exception:
+        return None
+
+
+def _render_text_preview(text: str, language: str) -> Optional[str]:
+    if CONSOLE and Syntax:
+        try:
+            syntax = Syntax(text, language, theme="monokai", word_wrap=True)
+            CONSOLE.print(syntax)
+            return "rich"
+        except Exception:
+            pass
+    if CONSOLE and Panel:
+        try:
+            CONSOLE.print(Panel(text, title=language.upper()))
+            return "panel"
+        except Exception:
+            pass
+    print(text)
+    return "text"
+
+
+def _truncate_text(text: str, limit: int = 2000) -> Tuple[str, bool]:
+    if len(text) <= limit:
+        return text, False
+    truncated = text[: max(0, limit - 1)].rstrip()
+    if not truncated.endswith("…"):
+        truncated += "\n…"
+    return truncated, True
+
+
+def _describe_preview(source: Optional[str], truncated: bool = False) -> Optional[str]:
+    if not source and not truncated:
+        return None
+
+    label_map = {
+        "rich": "inline preview via Rich",
+        "panel": "inline preview",
+        "text": "inline preview",
+        "sixel": "inline preview via sixel",
+    }
+
+    label = label_map.get(source)
+
+    if not label and truncated:
+        label = "truncated preview"
+
+    if label and truncated:
+        label = f"{label} (truncated)"
+
+    return label
+
+
+def _format_artifact_transcript(artifact: Artifact) -> str:
+    icon = ARTIFACT_ICONS.get(artifact.kind, "📦")
+    size_suffix = ""
+    if artifact.size_bytes is not None:
+        size_suffix = f" ({_format_size(artifact.size_bytes)})"
+
+    preview_line = artifact.preview_label or "Preview unavailable"
+
+    lines = [
+        f"{icon} Artifact {artifact.id}: {artifact.description}{size_suffix}",
+        f"  Preview: {preview_line}",
+        f"  Quick actions: :open {artifact.id} | :save {artifact.id} <path> | :discard {artifact.id}",
+    ]
+
+    return "\n".join(lines)
+
+
+def _format_size(size: int) -> str:
+    if size < 1024:
+        return f"{size} B"
+    for unit in ["KB", "MB", "GB", "TB"]:
+        size /= 1024
+        if size < 1024 or unit == "TB":
+            return f"{size:.1f} {unit}"
+    return f"{size:.1f} TB"
 
 
 def open_file(file_path):


### PR DESCRIPTION
## Summary
- add an artifact manager to lazily materialize generated files and handle cleanup
- render inline previews for image, HTML, and JavaScript outputs before offering external viewers
- expose :open, :save, and :discard terminal quick actions that operate on cached artifacts

## Testing
- python -m compileall src/open_interpreter/interfaces/terminal/utils/display_output.py src/open_interpreter/interfaces/terminal/utils/artifact_manager.py src/open_interpreter/interfaces/terminal/terminal_interface.py

------
https://chatgpt.com/codex/tasks/task_e_68d6388eedd8832e84221ea7e6001c00